### PR TITLE
Implement moderated chat and support experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# .NET build
+bin/
+obj/
+
+# Node
+node_modules/
+.next/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Env
+.env*
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# NabTeams Conversational Modules
+
+این مخزن شامل پیاده‌سازی اولیه‌ی بک‌اند ASP.NET Core و فرانت‌اند Next.js برای قابلیت‌های «چت گلوبال نقش‌محور با پایش Gemini» و «چت پشتیبانی دانشی» است.
+
+## ساختار
+
+```
+backend/           # وب‌سرویس ASP.NET Core (Minimal API + Controllers)
+frontend/          # اپ Next.js با App Router
+implementation_plan.md  # سند طراحی و تحلیل قبلی
+```
+
+## راه‌اندازی بک‌اند
+
+1. نصب پیش‌نیازها: [.NET 8 SDK](https://dotnet.microsoft.com/download).
+2. اجرای دستورات:
+   ```bash
+   cd backend/NabTeams.Api
+   dotnet restore
+   dotnet run --urls http://localhost:5000
+   ```
+3. مستندات Swagger در مسیر `http://localhost:5000/swagger` در دسترس است.
+
+### نقاط کلیدی API
+
+- `POST /api/chat/{role}/messages` — ارسال پیام و دریافت نتیجه‌ی پایش.
+- `GET /api/chat/{role}/messages` — دریافت پیام‌های منتشر شده در کانال نقش.
+- `GET /api/moderation/{role}/logs` — مشاهده‌ی لاگ‌های پایش اخیر.
+- `GET /api/discipline/{role}/{userId}` — وضعیت امتیاز انضباطی کاربر.
+- `POST /api/support/query` — پرسش از چت پشتیبانی دانشی.
+
+## راه‌اندازی فرانت‌اند
+
+1. نصب [Node.js 18+](https://nodejs.org/).
+2. اجرای دستورات:
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+3. وب‌اپ در `http://localhost:3000` با فرض اجرای بک‌اند روی `http://localhost:5000` در دسترس خواهد بود.
+
+> برای تغییر آدرس سرویس بک‌اند متغیر محیطی `NEXT_PUBLIC_API_URL` را تنظیم کنید.
+
+## قابلیت‌های مهم
+
+- **پایش محتوایی هم‌زمان:** سرویس `GeminiModerationService` پیام را ارزیابی کرده و بر اساس سطح ریسک خروجی Publish/Hold/Block می‌دهد.
+- **نرخ‌دهی و امتیاز منفی:** Rate Limiter پیام‌های پشت سر هم را محدود کرده و امتیاز منفی در `InMemoryUserDisciplineStore` ذخیره می‌شود.
+- **گزارش‌دهی:** لاگ‌ها و امتیازات از طریق API قابل دسترسی است.
+- **پشتیبانی مبتنی بر دانش:** مولفه‌ی `SupportResponder` با روش شباهت واژگانی ساده پاسخ را از منابع آماده می‌سازد و میزان اطمینان را اعلام می‌کند.
+- **فرانت‌اند راست‌به‌چپ:** رابط کاربری داشبورد، چت و پشتیبانی با واکنش‌گرایی و نمایش وضعیت پایش طراحی شده است.
+
+## گام‌های بعدی پیشنهادی
+
+- جایگزینی سرویس‌های شبیه‌سازی‌شده با اتصال واقعی به Google Gemini (Moderation و RAG).
+- اتصال به پایگاه‌داده پایدار (SQL/NoSQL) به جای ذخیره‌سازی در حافظه.
+- افزودن احراز هویت Single Sign-On و مدیریت نشست کاربر.
+- توسعه‌ی ماژول اعتراض (Appeal) و مدیریت دانش در پنل ادمین.

--- a/backend/NabTeams.Api/Controllers/ChatController.cs
+++ b/backend/NabTeams.Api/Controllers/ChatController.cs
@@ -1,0 +1,136 @@
+using Microsoft.AspNetCore.Mvc;
+using NabTeams.Api.Models;
+using NabTeams.Api.Services;
+using NabTeams.Api.Stores;
+
+namespace NabTeams.Api.Controllers;
+
+[ApiController]
+[Route("api/chat")]
+public class ChatController : ControllerBase
+{
+    private readonly IChatRepository _chatRepository;
+    private readonly IModerationService _moderationService;
+    private readonly IModerationLogStore _moderationLogStore;
+    private readonly IUserDisciplineStore _userDisciplineStore;
+    private readonly IRateLimiter _rateLimiter;
+
+    public ChatController(
+        IChatRepository chatRepository,
+        IModerationService moderationService,
+        IModerationLogStore moderationLogStore,
+        IUserDisciplineStore userDisciplineStore,
+        IRateLimiter rateLimiter)
+    {
+        _chatRepository = chatRepository;
+        _moderationService = moderationService;
+        _moderationLogStore = moderationLogStore;
+        _userDisciplineStore = userDisciplineStore;
+        _rateLimiter = rateLimiter;
+    }
+
+    [HttpGet("{role}/messages")]
+    public async Task<ActionResult<MessagesResponse>> GetMessagesAsync(string role, CancellationToken cancellationToken)
+    {
+        if (!RoleChannelExtensions.TryParse(role, out var channel))
+        {
+            return BadRequest("نقش نامعتبر است.");
+        }
+
+        var messages = await _chatRepository.GetMessagesAsync(channel, cancellationToken);
+        return Ok(new MessagesResponse { Messages = messages });
+    }
+
+    [HttpPost("{role}/messages")]
+    public async Task<ActionResult<SendMessageResponse>> SendMessageAsync(string role, [FromBody] SendMessageRequest request, CancellationToken cancellationToken)
+    {
+        if (!RoleChannelExtensions.TryParse(role, out var channel))
+        {
+            return BadRequest("نقش نامعتبر است.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.UserId) || string.IsNullOrWhiteSpace(request.Content))
+        {
+            return BadRequest("شناسه کاربر و متن پیام الزامی است.");
+        }
+
+        var rateResult = _rateLimiter.CheckQuota(request.UserId, channel);
+        if (!rateResult.Allowed)
+        {
+            return StatusCode(429, new SendMessageResponse
+            {
+                MessageId = Guid.Empty,
+                Status = MessageStatus.Blocked,
+                ModerationRisk = 0,
+                ModerationTags = Array.Empty<string>(),
+                ModerationNotes = rateResult.Message,
+                PenaltyPoints = 0,
+                SoftWarn = false,
+                RateLimitMessage = rateResult.Message
+            });
+        }
+
+        var candidate = new MessageCandidate(request.UserId, channel, request.Content);
+        var moderation = await _moderationService.ModerateAsync(candidate, cancellationToken);
+
+        var status = moderation.Decision switch
+        {
+            ModerationDecision.Publish or ModerationDecision.SoftWarn => MessageStatus.Published,
+            ModerationDecision.Hold => MessageStatus.Held,
+            _ => MessageStatus.Blocked
+        };
+
+        var message = new Message
+        {
+            Channel = channel,
+            SenderUserId = request.UserId,
+            Content = request.Content,
+            Status = status,
+            ModerationRisk = moderation.RiskScore,
+            ModerationTags = moderation.PolicyTags,
+            ModerationNotes = moderation.Notes,
+            PenaltyPoints = moderation.PenaltyPoints
+        };
+
+        if (status != MessageStatus.Blocked)
+        {
+            await _chatRepository.AddMessageAsync(message, cancellationToken);
+        }
+
+        var log = new ModerationLog
+        {
+            MessageId = message.Id,
+            UserId = request.UserId,
+            Channel = channel,
+            RiskScore = moderation.RiskScore,
+            PolicyTags = moderation.PolicyTags,
+            ActionTaken = moderation.Decision.ToString(),
+            PenaltyPoints = moderation.PenaltyPoints
+        };
+        await _moderationLogStore.AddAsync(log, cancellationToken);
+
+        if (moderation.PenaltyPoints != 0)
+        {
+            await _userDisciplineStore.UpdateScoreAsync(request.UserId, channel, -moderation.PenaltyPoints, moderation.Notes, message.Id, cancellationToken);
+        }
+
+        var response = new SendMessageResponse
+        {
+            MessageId = message.Id,
+            Status = status,
+            ModerationRisk = moderation.RiskScore,
+            ModerationTags = moderation.PolicyTags,
+            ModerationNotes = moderation.Notes,
+            PenaltyPoints = moderation.PenaltyPoints,
+            SoftWarn = moderation.Decision == ModerationDecision.SoftWarn
+        };
+
+        return moderation.Decision switch
+        {
+            ModerationDecision.Publish or ModerationDecision.SoftWarn => Ok(response),
+            ModerationDecision.Hold => StatusCode(StatusCodes.Status202Accepted, response),
+            ModerationDecision.Block or ModerationDecision.BlockAndReport => StatusCode(StatusCodes.Status403Forbidden, response),
+            _ => Ok(response)
+        };
+    }
+}

--- a/backend/NabTeams.Api/Controllers/DisciplineController.cs
+++ b/backend/NabTeams.Api/Controllers/DisciplineController.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Mvc;
+using NabTeams.Api.Models;
+using NabTeams.Api.Stores;
+
+namespace NabTeams.Api.Controllers;
+
+[ApiController]
+[Route("api/discipline")]
+public class DisciplineController : ControllerBase
+{
+    private readonly IUserDisciplineStore _disciplineStore;
+
+    public DisciplineController(IUserDisciplineStore disciplineStore)
+    {
+        _disciplineStore = disciplineStore;
+    }
+
+    [HttpGet("{role}/{userId}")]
+    public async Task<ActionResult<UserDiscipline>> GetAsync(string role, string userId, CancellationToken cancellationToken)
+    {
+        if (!RoleChannelExtensions.TryParse(role, out var channel))
+        {
+            return BadRequest("نقش نامعتبر است.");
+        }
+
+        var record = await _disciplineStore.GetAsync(userId, channel, cancellationToken);
+        if (record is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(record);
+    }
+}

--- a/backend/NabTeams.Api/Controllers/ModerationController.cs
+++ b/backend/NabTeams.Api/Controllers/ModerationController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using NabTeams.Api.Models;
+using NabTeams.Api.Stores;
+
+namespace NabTeams.Api.Controllers;
+
+[ApiController]
+[Route("api/moderation")]
+public class ModerationController : ControllerBase
+{
+    private readonly IModerationLogStore _logStore;
+
+    public ModerationController(IModerationLogStore logStore)
+    {
+        _logStore = logStore;
+    }
+
+    [HttpGet("{role}/logs")]
+    public async Task<ActionResult<IReadOnlyCollection<ModerationLog>>> GetLogsAsync(string role, CancellationToken cancellationToken)
+    {
+        if (!RoleChannelExtensions.TryParse(role, out var channel))
+        {
+            return BadRequest("نقش نامعتبر است.");
+        }
+
+        var logs = await _logStore.QueryAsync(channel, cancellationToken);
+        return Ok(logs);
+    }
+}

--- a/backend/NabTeams.Api/Controllers/SupportController.cs
+++ b/backend/NabTeams.Api/Controllers/SupportController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using NabTeams.Api.Models;
+using NabTeams.Api.Services;
+
+namespace NabTeams.Api.Controllers;
+
+[ApiController]
+[Route("api/support")]
+public class SupportController : ControllerBase
+{
+    private readonly ISupportResponder _responder;
+
+    public SupportController(ISupportResponder responder)
+    {
+        _responder = responder;
+    }
+
+    [HttpPost("query")]
+    public async Task<ActionResult<SupportAnswer>> QueryAsync([FromBody] SupportQuery query, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(query.UserId) || string.IsNullOrWhiteSpace(query.Question))
+        {
+            return BadRequest("شناسه کاربر و سوال الزامی است.");
+        }
+
+        var answer = await _responder.GetAnswerAsync(query, cancellationToken);
+        return Ok(answer);
+    }
+}

--- a/backend/NabTeams.Api/Models/Message.cs
+++ b/backend/NabTeams.Api/Models/Message.cs
@@ -1,0 +1,51 @@
+namespace NabTeams.Api.Models;
+
+public enum MessageStatus
+{
+    Published,
+    Held,
+    Blocked
+}
+
+public record Message
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public RoleChannel Channel { get; init; }
+    public string SenderUserId { get; init; } = string.Empty;
+    public string Content { get; init; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+    public MessageStatus Status { get; init; }
+    public double ModerationRisk { get; init; }
+    public IReadOnlyCollection<string> ModerationTags { get; init; } = Array.Empty<string>();
+    public string? ModerationNotes { get; init; }
+    public int PenaltyPoints { get; init; }
+};
+
+public record ModerationLog
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public Guid MessageId { get; init; }
+    public string UserId { get; init; } = string.Empty;
+    public RoleChannel Channel { get; init; }
+    public double RiskScore { get; init; }
+    public IReadOnlyCollection<string> PolicyTags { get; init; } = Array.Empty<string>();
+    public string ActionTaken { get; init; } = string.Empty;
+    public int PenaltyPoints { get; init; }
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+};
+
+public record UserDiscipline
+{
+    public string UserId { get; init; } = string.Empty;
+    public RoleChannel Channel { get; init; }
+    public int ScoreBalance { get; set; }
+    public List<DisciplineEvent> History { get; } = new();
+}
+
+public record DisciplineEvent
+{
+    public DateTimeOffset OccurredAt { get; init; } = DateTimeOffset.UtcNow;
+    public string Reason { get; init; } = string.Empty;
+    public int Delta { get; init; }
+    public Guid MessageId { get; init; }
+}

--- a/backend/NabTeams.Api/Models/Requests.cs
+++ b/backend/NabTeams.Api/Models/Requests.cs
@@ -1,0 +1,24 @@
+namespace NabTeams.Api.Models;
+
+public record SendMessageRequest
+{
+    public string UserId { get; init; } = string.Empty;
+    public string Content { get; init; } = string.Empty;
+}
+
+public record SendMessageResponse
+{
+    public Guid MessageId { get; init; }
+    public MessageStatus Status { get; init; }
+    public double ModerationRisk { get; init; }
+    public IReadOnlyCollection<string> ModerationTags { get; init; } = Array.Empty<string>();
+    public string? ModerationNotes { get; init; }
+    public int PenaltyPoints { get; init; }
+    public bool SoftWarn { get; init; }
+    public string? RateLimitMessage { get; init; }
+}
+
+public record MessagesResponse
+{
+    public IReadOnlyCollection<Message> Messages { get; init; } = Array.Empty<Message>();
+}

--- a/backend/NabTeams.Api/Models/RoleChannel.cs
+++ b/backend/NabTeams.Api/Models/RoleChannel.cs
@@ -1,0 +1,27 @@
+namespace NabTeams.Api.Models;
+
+public enum RoleChannel
+{
+    Participant,
+    Judge,
+    Mentor,
+    Investor,
+    Admin
+}
+
+public static class RoleChannelExtensions
+{
+    public static bool TryParse(string value, out RoleChannel channel)
+    {
+        if (Enum.TryParse<RoleChannel>(value, true, out var parsed))
+        {
+            channel = parsed;
+            return true;
+        }
+
+        channel = default;
+        return false;
+    }
+
+    public static string ToRouteSegment(this RoleChannel channel) => channel.ToString().ToLowerInvariant();
+}

--- a/backend/NabTeams.Api/Models/SupportModels.cs
+++ b/backend/NabTeams.Api/Models/SupportModels.cs
@@ -1,0 +1,26 @@
+namespace NabTeams.Api.Models;
+
+public record SupportQuery
+{
+    public string Question { get; init; } = string.Empty;
+    public string Role { get; init; } = string.Empty;
+    public string UserId { get; init; } = string.Empty;
+}
+
+public record SupportAnswer
+{
+    public string Answer { get; init; } = string.Empty;
+    public IReadOnlyCollection<string> Sources { get; init; } = Array.Empty<string>();
+    public double Confidence { get; init; }
+    public bool EscalateToHuman { get; init; }
+}
+
+public record KnowledgeBaseItem
+{
+    public string Id { get; init; } = Guid.NewGuid().ToString();
+    public string Title { get; init; } = string.Empty;
+    public string Body { get; init; } = string.Empty;
+    public string Audience { get; init; } = "all";
+    public IReadOnlyCollection<string> Tags { get; init; } = Array.Empty<string>();
+    public DateTimeOffset UpdatedAt { get; init; } = DateTimeOffset.UtcNow;
+}

--- a/backend/NabTeams.Api/NabTeams.Api.csproj
+++ b/backend/NabTeams.Api/NabTeams.Api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/backend/NabTeams.Api/Program.cs
+++ b/backend/NabTeams.Api/Program.cs
@@ -1,0 +1,37 @@
+using NabTeams.Api.Services;
+using NabTeams.Api.Stores;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddSingleton<IChatRepository, InMemoryChatRepository>();
+builder.Services.AddSingleton<IModerationLogStore, InMemoryModerationLogStore>();
+builder.Services.AddSingleton<IUserDisciplineStore, InMemoryUserDisciplineStore>();
+builder.Services.AddSingleton<IRateLimiter, SlidingWindowRateLimiter>();
+builder.Services.AddSingleton<IModerationService, GeminiModerationService>();
+builder.Services.AddSingleton<ISupportKnowledgeBase, InMemorySupportKnowledgeBase>();
+builder.Services.AddSingleton<ISupportResponder, SupportResponder>();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("frontend", policy =>
+        policy.WithOrigins("http://localhost:3000")
+              .AllowAnyHeader()
+              .AllowAnyMethod());
+});
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseCors("frontend");
+app.MapControllers();
+
+app.Run();

--- a/backend/NabTeams.Api/Services/GeminiModerationService.cs
+++ b/backend/NabTeams.Api/Services/GeminiModerationService.cs
@@ -1,0 +1,114 @@
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Services;
+
+public class GeminiModerationService : IModerationService
+{
+    private static readonly IReadOnlyList<PolicyRule> Rules = new List<PolicyRule>
+    {
+        new("hate", "گروه", 0.75, 6),
+        new("violence", "تهدید", 0.7, 5),
+        new("spam", "اسپم", 0.55, 3),
+        new("cheat", "تقلب", 0.65, 4),
+        new("leak", "افشای اطلاعات", 0.8, 6),
+        new("http://", "لینک", 0.4, 1),
+        new("https://", "لینک", 0.4, 1),
+        new("کدملی", "اطلاعات حساس", 0.85, 8),
+        new("خودکشی", "خودآسیب", 0.9, 10)
+    };
+
+    private static readonly Regex ProfanityRegex = new("(?i)(لعنتی|احمق|stupid|idiot)", RegexOptions.Compiled);
+
+    private static readonly ConcurrentDictionary<string, double> TrustAdjustments = new();
+
+    public Task<ModerationResult> ModerateAsync(MessageCandidate candidate, CancellationToken cancellationToken = default)
+    {
+        var lowered = candidate.Content.ToLowerInvariant();
+        var matchedTags = new HashSet<string>();
+        double risk = 0.05; // base noise floor
+        int penalty = 0;
+
+        foreach (var rule in Rules)
+        {
+            if (!lowered.Contains(rule.Keyword))
+            {
+                continue;
+            }
+
+            matchedTags.Add(rule.PolicyTag);
+            risk = Math.Max(risk, rule.RiskScore);
+            penalty = Math.Max(penalty, rule.PenaltyPoints);
+        }
+
+        if (ProfanityRegex.IsMatch(candidate.Content))
+        {
+            matchedTags.Add("توهین");
+            risk = Math.Max(risk, 0.6);
+            penalty = Math.Max(penalty, 4);
+        }
+
+        if (candidate.Content.Length > 600)
+        {
+            matchedTags.Add("پیام طولانی");
+            risk = Math.Max(risk, 0.3);
+        }
+
+        var trustAdjustment = TrustAdjustments.GetOrAdd(candidate.UserId, _ => 0);
+        risk = Math.Clamp(risk + trustAdjustment, 0, 1);
+
+        var decision = DetermineDecision(risk, matchedTags.Count);
+        var notes = decision switch
+        {
+            ModerationDecision.Publish => "پیام سالم شناسایی شد.",
+            ModerationDecision.SoftWarn => "پیام منتشر شد اما شامل علائم ریسک است.",
+            ModerationDecision.Hold => "پیام برای بررسی انسانی نگه داشته شد.",
+            ModerationDecision.Block => "پیام مسدود شد و به کاربر هشدار داده می‌شود.",
+            ModerationDecision.BlockAndReport => "پیام مسدود و برای پیگیری ادمین پرچم شد.",
+            _ => ""
+        };
+
+        if (decision is ModerationDecision.Publish or ModerationDecision.SoftWarn)
+        {
+            TrustAdjustments.AddOrUpdate(candidate.UserId, _ => -0.05, (_, current) => Math.Max(-0.1, current - 0.05));
+        }
+        else
+        {
+            TrustAdjustments.AddOrUpdate(candidate.UserId, _ => 0.1, (_, current) => Math.Min(0.2, current + 0.05));
+        }
+
+        penalty = decision switch
+        {
+            ModerationDecision.Publish => 0,
+            ModerationDecision.SoftWarn => Math.Max(penalty, 0),
+            ModerationDecision.Hold => Math.Max(penalty, 1),
+            ModerationDecision.Block => Math.Max(penalty, 3),
+            ModerationDecision.BlockAndReport => Math.Max(penalty, 5),
+            _ => penalty
+        };
+
+        var result = new ModerationResult(
+            Math.Round(risk, 2),
+            matchedTags.ToList(),
+            decision,
+            notes,
+            penalty);
+
+        return Task.FromResult(result);
+    }
+
+    private static ModerationDecision DetermineDecision(double risk, int tagCount)
+    {
+        return risk switch
+        {
+            <= 0.2 => ModerationDecision.Publish,
+            <= 0.4 => ModerationDecision.SoftWarn,
+            <= 0.6 => ModerationDecision.Hold,
+            <= 0.8 => ModerationDecision.Block,
+            _ => ModerationDecision.BlockAndReport
+        };
+    }
+
+    private sealed record PolicyRule(string Keyword, string PolicyTag, double RiskScore, int PenaltyPoints);
+}

--- a/backend/NabTeams.Api/Services/IModerationService.cs
+++ b/backend/NabTeams.Api/Services/IModerationService.cs
@@ -1,0 +1,26 @@
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Services;
+
+public record ModerationResult(
+    double RiskScore,
+    IReadOnlyCollection<string> PolicyTags,
+    ModerationDecision Decision,
+    string Notes,
+    int PenaltyPoints);
+
+public enum ModerationDecision
+{
+    Publish,
+    SoftWarn,
+    Hold,
+    Block,
+    BlockAndReport
+}
+
+public record MessageCandidate(string UserId, RoleChannel Channel, string Content);
+
+public interface IModerationService
+{
+    Task<ModerationResult> ModerateAsync(MessageCandidate candidate, CancellationToken cancellationToken = default);
+}

--- a/backend/NabTeams.Api/Services/IRateLimiter.cs
+++ b/backend/NabTeams.Api/Services/IRateLimiter.cs
@@ -1,0 +1,10 @@
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Services;
+
+public record RateLimitResult(bool Allowed, TimeSpan? RetryAfter, string? Message);
+
+public interface IRateLimiter
+{
+    RateLimitResult CheckQuota(string userId, RoleChannel channel);
+}

--- a/backend/NabTeams.Api/Services/SlidingWindowRateLimiter.cs
+++ b/backend/NabTeams.Api/Services/SlidingWindowRateLimiter.cs
@@ -1,0 +1,41 @@
+using System.Collections.Concurrent;
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Services;
+
+public class SlidingWindowRateLimiter : IRateLimiter
+{
+    private record RateLimitConfig(int MaxMessages, TimeSpan Window);
+
+    private readonly ConcurrentDictionary<(string UserId, RoleChannel Channel), Queue<DateTimeOffset>> _entries = new();
+    private readonly IReadOnlyDictionary<RoleChannel, RateLimitConfig> _configs = new Dictionary<RoleChannel, RateLimitConfig>
+    {
+        { RoleChannel.Participant, new RateLimitConfig(20, TimeSpan.FromMinutes(5)) },
+        { RoleChannel.Judge, new RateLimitConfig(30, TimeSpan.FromMinutes(5)) },
+        { RoleChannel.Mentor, new RateLimitConfig(25, TimeSpan.FromMinutes(5)) },
+        { RoleChannel.Investor, new RateLimitConfig(15, TimeSpan.FromMinutes(5)) },
+        { RoleChannel.Admin, new RateLimitConfig(40, TimeSpan.FromMinutes(5)) }
+    };
+
+    public RateLimitResult CheckQuota(string userId, RoleChannel channel)
+    {
+        var config = _configs[channel];
+        var now = DateTimeOffset.UtcNow;
+        var key = (userId, channel);
+        var queue = _entries.GetOrAdd(key, _ => new Queue<DateTimeOffset>());
+
+        while (queue.Count > 0 && now - queue.Peek() > config.Window)
+        {
+            queue.Dequeue();
+        }
+
+        if (queue.Count >= config.MaxMessages)
+        {
+            var retryAfter = config.Window - (now - queue.Peek());
+            return new RateLimitResult(false, retryAfter, $"نرخ ارسال پیام شما محدود شده است. لطفاً {retryAfter.TotalSeconds:N0} ثانیه صبر کنید.");
+        }
+
+        queue.Enqueue(now);
+        return new RateLimitResult(true, null, null);
+    }
+}

--- a/backend/NabTeams.Api/Services/SupportResponder.cs
+++ b/backend/NabTeams.Api/Services/SupportResponder.cs
@@ -1,0 +1,124 @@
+using System.Text.RegularExpressions;
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Services;
+
+public interface ISupportKnowledgeBase
+{
+    IReadOnlyCollection<KnowledgeBaseItem> Items { get; }
+}
+
+public interface ISupportResponder
+{
+    Task<SupportAnswer> GetAnswerAsync(SupportQuery query, CancellationToken cancellationToken = default);
+}
+
+public class InMemorySupportKnowledgeBase : ISupportKnowledgeBase
+{
+    public IReadOnlyCollection<KnowledgeBaseItem> Items { get; } = new List<KnowledgeBaseItem>
+    {
+        new()
+        {
+            Id = "event-rules",
+            Title = "قوانین کلی رویداد",
+            Body = "شرکت‌کنندگان باید قوانین اخلاقی و حرفه‌ای را رعایت کنند. ساعات برگزاری از 9 تا 18 می‌باشد.",
+            Audience = "participant",
+            Tags = new[] { "rules", "schedule" }
+        },
+        new()
+        {
+            Id = "mentor-support",
+            Title = "نقش منتورها",
+            Body = "منتورها می‌توانند از طریق داشبورد منتور مستقیماً با تیم‌ها گفتگو کنند و دسترسی به اتاق‌های منتورینگ دارند.",
+            Audience = "mentor",
+            Tags = new[] { "mentor", "access" }
+        },
+        new()
+        {
+            Id = "contact-admin",
+            Title = "راه‌های ارتباطی با ادمین",
+            Body = "برای مسائل اضطراری با شماره 021-000000 تماس بگیرید یا از فرم تیکت در داشبورد استفاده کنید.",
+            Audience = "all",
+            Tags = new[] { "contact", "support" }
+        },
+        new()
+        {
+            Id = "investor-brief",
+            Title = "دسترسی سرمایه‌گذاران",
+            Body = "سرمایه‌گذاران به داشبورد ارزیابی مالی و گزارش‌های تیم‌ها دسترسی دارند. نسخه به‌روزشده هر روز ساعت 12 منتشر می‌شود.",
+            Audience = "investor",
+            Tags = new[] { "investor", "reports" }
+        }
+    };
+}
+
+public class SupportResponder : ISupportResponder
+{
+    private readonly ISupportKnowledgeBase _knowledgeBase;
+
+    public SupportResponder(ISupportKnowledgeBase knowledgeBase)
+    {
+        _knowledgeBase = knowledgeBase;
+    }
+
+    public Task<SupportAnswer> GetAnswerAsync(SupportQuery query, CancellationToken cancellationToken = default)
+    {
+        var normalizedRole = string.IsNullOrWhiteSpace(query.Role) ? "all" : query.Role.ToLowerInvariant();
+        var roleTokens = Tokenize(query.Question);
+        var items = _knowledgeBase.Items
+            .Where(item => item.Audience == "all" || item.Audience.Equals(normalizedRole, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (!items.Any())
+        {
+            return Task.FromResult(new SupportAnswer
+            {
+                Answer = "هیچ منبعی برای نقش شما ثبت نشده است. لطفاً با ادمین تماس بگیرید.",
+                Confidence = 0,
+                EscalateToHuman = true
+            });
+        }
+
+        var scored = new List<(KnowledgeBaseItem Item, double Score)>();
+        foreach (var item in items)
+        {
+            var itemTokens = Tokenize(item.Body + " " + item.Title);
+            var overlap = roleTokens.Intersect(itemTokens).Count();
+            var score = overlap / (double)(roleTokens.Count + 1);
+            if (score > 0)
+            {
+                scored.Add((item, score));
+            }
+        }
+
+        if (!scored.Any())
+        {
+            return Task.FromResult(new SupportAnswer
+            {
+                Answer = "برای این سوال پاسخ دقیقی ندارم. لطفاً سوال را دقیق‌تر بیان کنید یا با تیم پشتیبانی تماس بگیرید.",
+                Confidence = 0.2,
+                EscalateToHuman = true
+            });
+        }
+
+        var best = scored.OrderByDescending(x => x.Score).First();
+        var confidence = Math.Clamp(best.Score, 0, 1);
+
+        var answer = new SupportAnswer
+        {
+            Answer = $"{best.Item.Title}: {best.Item.Body}",
+            Sources = new[] { best.Item.Id },
+            Confidence = confidence,
+            EscalateToHuman = confidence < 0.35
+        };
+
+        return Task.FromResult(answer);
+    }
+
+    private static IReadOnlyCollection<string> Tokenize(string text)
+    {
+        text = text.ToLowerInvariant();
+        text = Regex.Replace(text, "[^\\p{L}\\p{Nd} ]+", " ");
+        return text.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+}

--- a/backend/NabTeams.Api/Stores/IChatRepository.cs
+++ b/backend/NabTeams.Api/Stores/IChatRepository.cs
@@ -1,0 +1,21 @@
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Stores;
+
+public interface IChatRepository
+{
+    Task AddMessageAsync(Message message, CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<Message>> GetMessagesAsync(RoleChannel channel, CancellationToken cancellationToken = default);
+}
+
+public interface IModerationLogStore
+{
+    Task AddAsync(ModerationLog log, CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<ModerationLog>> QueryAsync(RoleChannel channel, CancellationToken cancellationToken = default);
+}
+
+public interface IUserDisciplineStore
+{
+    Task<UserDiscipline> UpdateScoreAsync(string userId, RoleChannel channel, int delta, string reason, Guid messageId, CancellationToken cancellationToken = default);
+    Task<UserDiscipline?> GetAsync(string userId, RoleChannel channel, CancellationToken cancellationToken = default);
+}

--- a/backend/NabTeams.Api/Stores/InMemoryStores.cs
+++ b/backend/NabTeams.Api/Stores/InMemoryStores.cs
@@ -1,0 +1,88 @@
+using System.Collections.Concurrent;
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Stores;
+
+public class InMemoryChatRepository : IChatRepository
+{
+    private readonly ConcurrentDictionary<RoleChannel, List<Message>> _messages = new();
+
+    public Task AddMessageAsync(Message message, CancellationToken cancellationToken = default)
+    {
+        var list = _messages.GetOrAdd(message.Channel, _ => new List<Message>());
+        lock (list)
+        {
+            list.Add(message);
+            if (list.Count > 500)
+            {
+                list.RemoveRange(0, list.Count - 500);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyCollection<Message>> GetMessagesAsync(RoleChannel channel, CancellationToken cancellationToken = default)
+    {
+        var list = _messages.GetOrAdd(channel, _ => new List<Message>());
+        lock (list)
+        {
+            return Task.FromResult((IReadOnlyCollection<Message>)list.OrderBy(m => m.CreatedAt).ToList());
+        }
+    }
+}
+
+public class InMemoryModerationLogStore : IModerationLogStore
+{
+    private readonly ConcurrentBag<ModerationLog> _logs = new();
+
+    public Task AddAsync(ModerationLog log, CancellationToken cancellationToken = default)
+    {
+        _logs.Add(log);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyCollection<ModerationLog>> QueryAsync(RoleChannel channel, CancellationToken cancellationToken = default)
+    {
+        var results = _logs.Where(l => l.Channel == channel)
+            .OrderByDescending(l => l.CreatedAt)
+            .Take(100)
+            .ToList();
+        return Task.FromResult((IReadOnlyCollection<ModerationLog>)results);
+    }
+}
+
+public class InMemoryUserDisciplineStore : IUserDisciplineStore
+{
+    private readonly ConcurrentDictionary<(string UserId, RoleChannel Channel), UserDiscipline> _users = new();
+
+    public Task<UserDiscipline> UpdateScoreAsync(string userId, RoleChannel channel, int delta, string reason, Guid messageId, CancellationToken cancellationToken = default)
+    {
+        var key = (userId, channel);
+        var record = _users.GetOrAdd(key, _ => new UserDiscipline
+        {
+            UserId = userId,
+            Channel = channel
+        });
+
+        lock (record)
+        {
+            record.ScoreBalance += delta;
+            record.History.Add(new DisciplineEvent
+            {
+                Delta = delta,
+                MessageId = messageId,
+                Reason = reason,
+                OccurredAt = DateTimeOffset.UtcNow
+            });
+        }
+
+        return Task.FromResult(record);
+    }
+
+    public Task<UserDiscipline?> GetAsync(string userId, RoleChannel channel, CancellationToken cancellationToken = default)
+    {
+        var key = (userId, channel);
+        return Task.FromResult(_users.TryGetValue(key, out var record) ? record : null);
+    }
+}

--- a/frontend/app/(dashboard)/global-chat/page.tsx
+++ b/frontend/app/(dashboard)/global-chat/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+import { ChatPanel } from '../../../components/chat-panel';
+
+export default function GlobalChatPage() {
+  return (
+    <div className="space-y-6">
+      <Link href="/" className="text-sm text-slate-400 hover:text-slate-200">
+        ← بازگشت به داشبورد
+      </Link>
+      <ChatPanel />
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/support/page.tsx
+++ b/frontend/app/(dashboard)/support/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+import { SupportPanel } from '../../../components/support-panel';
+
+export default function SupportPage() {
+  return (
+    <div className="space-y-6">
+      <Link href="/" className="text-sm text-slate-400 hover:text-slate-200">
+        ← بازگشت به داشبورد
+      </Link>
+      <SupportPanel />
+    </div>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,17 @@
+:root {
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,24 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { Rubik } from 'next/font/google';
+
+const rubik = Rubik({ subsets: ['latin', 'arabic'] });
+
+export const metadata: Metadata = {
+  title: 'NabTeams Dashboard',
+  description: 'Role-based collaboration with AI moderation and support'
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="fa" dir="rtl">
+      <body className={`${rubik.className} bg-slate-950 text-slate-100 min-h-screen`}>
+        <main className="max-w-6xl mx-auto px-4 py-6">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import { RoleSwitcher } from '../components/role-switcher';
+
+export default function HomePage() {
+  return (
+    <div className="space-y-8">
+      <header className="space-y-3">
+        <h1 className="text-3xl font-semibold">داشبورد تعاملی نب‌تیمز</h1>
+        <p className="text-slate-300 max-w-3xl">
+          این نسخه‌ی اولیه شامل چت گلوبال نقش‌محور با پایش محتوایی هوشمند و چت پشتیبانی مبتنی بر دانش ادمین است.
+          برای تست می‌توانید نقش دلخواه را انتخاب کرده و پیام ارسال کنید.
+        </p>
+        <RoleSwitcher />
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <Link
+          href="/(dashboard)/global-chat"
+          className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 hover:border-slate-600 transition"
+        >
+          <h2 className="text-2xl font-medium mb-2">👥 چت گلوبال</h2>
+          <p className="text-sm text-slate-300">
+            پیام‌های نقش خود را در کانال اختصاصی ارسال کنید و نتیجه‌ی پایش محتوایی را به صورت لحظه‌ای ببینید.
+          </p>
+        </Link>
+        <Link
+          href="/(dashboard)/support"
+          className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 hover:border-slate-600 transition"
+        >
+          <h2 className="text-2xl font-medium mb-2">🛟 پشتیبانی دانشی</h2>
+          <p className="text-sm text-slate-300">
+            پرسش‌های خود را مطرح کنید تا Gemini بر اساس دانش‌پایه‌ی ادمین پاسخ دهد و در صورت نیاز انتقال به اپراتور انجام شود.
+          </p>
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/frontend/components/chat-panel.tsx
+++ b/frontend/components/chat-panel.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { fetchMessages, MessageModel, Role, sendMessage } from '../lib/api';
+import { useRole } from '../lib/use-role';
+
+const roleLabels: Record<Role, string> = {
+  participant: 'شرکت‌کننده',
+  judge: 'داور',
+  mentor: 'منتور',
+  investor: 'سرمایه‌گذار',
+  admin: 'ادمین'
+};
+
+export function ChatPanel() {
+  const role = useRole() as Role;
+  const [userId, setUserId] = useState('user-001');
+  const [content, setContent] = useState('');
+  const [messages, setMessages] = useState<MessageModel[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const loadMessages = async () => {
+    try {
+      const data = await fetchMessages(role);
+      setMessages(data);
+    } catch (error) {
+      setFeedback((error as Error).message);
+    }
+  };
+
+  useEffect(() => {
+    loadMessages();
+    const interval = setInterval(loadMessages, 5000);
+    return () => clearInterval(interval);
+  }, [role]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!content.trim()) {
+      return;
+    }
+    setLoading(true);
+    setFeedback(null);
+    try {
+      const response = await sendMessage(role, { userId, content });
+      setFeedback(
+        response.rateLimitMessage ??
+          `${response.moderationNotes ?? ''} (ریسک: ${response.moderationRisk}, امتیاز منفی: ${response.penaltyPoints})`
+      );
+      setContent('');
+      await loadMessages();
+    } catch (error) {
+      setFeedback((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">کانال {roleLabels[role]}</h1>
+        <p className="text-slate-400 text-sm">
+          پیام‌ها پیش از انتشار توسط موتور Gemini ارزیابی می‌شوند. خروجی شامل وضعیت، امتیاز ریسک و هشدارها است.
+        </p>
+      </header>
+
+      <div className="rounded-2xl border border-slate-800 bg-slate-900/70">
+        <div className="max-h-[420px] overflow-y-auto divide-y divide-slate-800/60">
+          {messages.length === 0 ? (
+            <p className="p-6 text-sm text-slate-400">هنوز پیامی ارسال نشده است.</p>
+          ) : (
+            messages.map((message) => (
+              <article key={message.id} className="p-5 space-y-2">
+                <div className="flex justify-between text-xs text-slate-500">
+                  <span>کاربر: {message.senderUserId}</span>
+                  <span>{new Date(message.createdAt).toLocaleString('fa-IR')}</span>
+                </div>
+                <p className="text-sm leading-6 text-slate-100 whitespace-pre-wrap">{message.content}</p>
+                <footer className="flex flex-wrap gap-2 text-xs">
+                  <StatusBadge status={message.status} />
+                  <span className="rounded-full bg-slate-800 px-2 py-1">
+                    ریسک: {(message.moderationRisk * 100).toFixed(0)}%
+                  </span>
+                  {message.moderationTags.map((tag) => (
+                    <span key={tag} className="rounded-full bg-indigo-900/40 px-2 py-1 text-indigo-200">
+                      #{tag}
+                    </span>
+                  ))}
+                  {message.penaltyPoints !== 0 && (
+                    <span className="rounded-full bg-rose-900/40 px-2 py-1 text-rose-200">امتیاز منفی: {message.penaltyPoints}</span>
+                  )}
+                </footer>
+              </article>
+            ))
+          )}
+        </div>
+        <form onSubmit={handleSubmit} className="border-t border-slate-800 p-5 space-y-3">
+          <div className="flex flex-wrap gap-4 text-sm">
+            <label className="flex flex-col gap-1">
+              <span className="text-slate-400">شناسه کاربر</span>
+              <input
+                value={userId}
+                onChange={(event) => setUserId(event.target.value)}
+                className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100"
+              />
+            </label>
+          </div>
+          <textarea
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-3 text-sm text-slate-100"
+            placeholder="پیام خود را بنویسید..."
+            rows={3}
+          />
+          <div className="flex items-center justify-between text-xs text-slate-400">
+            <span>حداکثر 20 پیام در 5 دقیقه برای نقش شرکت‌کننده مجاز است.</span>
+            <button
+              type="submit"
+              disabled={loading}
+              className="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-medium text-emerald-950 disabled:opacity-60"
+            >
+              {loading ? 'در حال ارسال...' : 'ارسال پیام'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {feedback && <p className="text-sm text-amber-300">{feedback}</p>}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: MessageModel['status'] }) {
+  const styles: Record<MessageModel['status'], string> = {
+    Published: 'bg-emerald-900/50 text-emerald-200',
+    Held: 'bg-amber-900/40 text-amber-200',
+    Blocked: 'bg-rose-900/50 text-rose-100'
+  };
+  const labels: Record<MessageModel['status'], string> = {
+    Published: 'منتشر شد',
+    Held: 'در انتظار بررسی',
+    Blocked: 'مسدود شد'
+  };
+
+  return <span className={`rounded-full px-2 py-1 text-xs ${styles[status]}`}>{labels[status]}</span>;
+}

--- a/frontend/components/role-switcher.tsx
+++ b/frontend/components/role-switcher.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+
+const roles = [
+  { value: 'participant', label: 'شرکت‌کننده' },
+  { value: 'judge', label: 'داور' },
+  { value: 'mentor', label: 'منتور' },
+  { value: 'investor', label: 'سرمایه‌گذار' },
+  { value: 'admin', label: 'ادمین' }
+];
+
+export function RoleSwitcher() {
+  const [role, setRole] = useState('participant');
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 text-sm">
+      <span className="text-slate-400">نقش آزمایشی:</span>
+      <div className="flex gap-2">
+        {roles.map((item) => (
+          <button
+            key={item.value}
+            onClick={() => {
+              localStorage.setItem('nabteams:role', item.value);
+              setRole(item.value);
+            }}
+            className={`rounded-full border px-3 py-1 transition ${
+              role === item.value ? 'border-emerald-400 bg-emerald-500/20 text-emerald-100' : 'border-slate-700 bg-slate-800'
+            }`}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/support-panel.tsx
+++ b/frontend/components/support-panel.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState } from 'react';
+import { askSupport, Role, SupportAnswer } from '../lib/api';
+import { useRole } from '../lib/use-role';
+
+export function SupportPanel() {
+  const role = useRole() as Role;
+  const [userId, setUserId] = useState('user-001');
+  const [question, setQuestion] = useState('قوانین عمومی رویداد چیست؟');
+  const [answer, setAnswer] = useState<SupportAnswer | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!question.trim()) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await askSupport({
+        userId,
+        role,
+        question
+      });
+      setAnswer(result);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">پشتیبانی هوشمند</h1>
+        <p className="text-slate-400 text-sm">
+          پاسخ‌ها از دانش‌پایه‌ی منتشر شده توسط ادمین و منابع داخلی تامین می‌شود. در صورت اطمینان پایین، پیشنهاد تماس انسانی ارائه می‌گردد.
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-5">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-slate-400">شناسه کاربر</span>
+            <input
+              value={userId}
+              onChange={(event) => setUserId(event.target.value)}
+              className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-slate-400">نقش فعال</span>
+            <input value={role} disabled className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100" />
+          </label>
+        </div>
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="text-slate-400">سوال شما</span>
+          <textarea
+            value={question}
+            onChange={(event) => setQuestion(event.target.value)}
+            rows={4}
+            className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-3 text-sm text-slate-100"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded-lg bg-sky-500 px-4 py-2 text-sm font-medium text-sky-950 disabled:opacity-60"
+        >
+          {loading ? 'در حال تحلیل...' : 'ارسال سوال'}
+        </button>
+      </form>
+
+      {answer && (
+        <section className="space-y-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-5">
+          <header className="flex flex-wrap items-center justify-between gap-3 text-sm">
+            <div className="flex items-center gap-2">
+              <span className="rounded-full bg-emerald-900/40 px-2 py-1 text-emerald-200">
+                اطمینان: {(answer.confidence * 100).toFixed(0)}%
+              </span>
+              {answer.escalateToHuman && (
+                <span className="rounded-full bg-amber-900/40 px-2 py-1 text-amber-200">پیشنهاد ارتباط انسانی</span>
+              )}
+            </div>
+            {answer.sources?.length > 0 && (
+              <div className="text-xs text-slate-400">منابع: {answer.sources.join(', ')}</div>
+            )}
+          </header>
+          <p className="leading-7 text-slate-100 whitespace-pre-wrap">{answer.answer}</p>
+        </section>
+      )}
+
+      {error && <p className="text-sm text-rose-300">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,82 @@
+export type Role = 'participant' | 'judge' | 'mentor' | 'investor' | 'admin';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:5000';
+
+export interface SendMessagePayload {
+  userId: string;
+  content: string;
+}
+
+export interface SendMessageResponse {
+  messageId: string;
+  status: 'Published' | 'Held' | 'Blocked';
+  moderationRisk: number;
+  moderationTags: string[];
+  moderationNotes?: string | null;
+  penaltyPoints: number;
+  softWarn: boolean;
+  rateLimitMessage?: string | null;
+}
+
+export interface MessageModel {
+  id: string;
+  channel: Role;
+  senderUserId: string;
+  content: string;
+  createdAt: string;
+  status: 'Published' | 'Held' | 'Blocked';
+  moderationRisk: number;
+  moderationTags: string[];
+  moderationNotes?: string | null;
+  penaltyPoints: number;
+}
+
+export interface SupportAnswer {
+  answer: string;
+  sources: string[];
+  confidence: number;
+  escalateToHuman: boolean;
+}
+
+export async function fetchMessages(role: Role): Promise<MessageModel[]> {
+  const res = await fetch(`${API_BASE}/api/chat/${role}/messages`, {
+    cache: 'no-store'
+  });
+  if (!res.ok) {
+    throw new Error('دریافت پیام‌ها با خطا مواجه شد');
+  }
+  const data = await res.json();
+  return data.messages ?? [];
+}
+
+export async function sendMessage(role: Role, payload: SendMessagePayload): Promise<SendMessageResponse> {
+  const res = await fetch(`${API_BASE}/api/chat/${role}/messages`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  const data = await res.json();
+  if (!res.ok && res.status !== 202 && res.status !== 403 && res.status !== 429) {
+    throw new Error(data?.message ?? 'ارسال پیام ناموفق بود');
+  }
+  return data as SendMessageResponse;
+}
+
+export async function askSupport(payload: { userId: string; role: Role; question: string }): Promise<SupportAnswer> {
+  const res = await fetch(`${API_BASE}/api/support/query`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!res.ok) {
+    throw new Error('دریافت پاسخ پشتیبانی ناموفق بود');
+  }
+
+  return res.json();
+}

--- a/frontend/lib/use-role.ts
+++ b/frontend/lib/use-role.ts
@@ -10,6 +10,18 @@ export function useRole() {
     if (stored) {
       setRole(stored);
     }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === 'nabteams:role') {
+        setRole(event.newValue || 'participant');
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+    };
   }, []);
 
   return role;

--- a/frontend/lib/use-role.ts
+++ b/frontend/lib/use-role.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useRole() {
+  const [role, setRole] = useState('participant');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('nabteams:role');
+    if (stored) {
+      setRole(stored);
+    }
+  }, []);
+
+  return role;
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,8 @@
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "nabteams-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.19",
+    "@types/react": "18.2.55",
+    "@types/react-dom": "18.2.18",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.4",
+    "typescript": "5.3.3"
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,0 +1,156 @@
+# Implementation Blueprint: Role-Based Global Chat with Gemini Moderation & Knowledge-Driven Support
+
+این سند تبدیل تحلیل مفهومی به نقشه‌ی اجرایی برای پیاده‌سازی بک‌اند مبتنی بر **.NET 8 (ASP.NET Core)** و فرانت‌اند **Next.js 14 (App Router)** است. هدف، ایجاد چت گلوبال نقش‌محور با پایش هوشمند Gemini و چت پشتیبانی دانشی است.
+
+---
+
+## 1. Architecture Overview
+
+- **Frontend**: Next.js 14، TypeScript، Server Actions، Zustand/Redux Toolkit برای state، Tailwind CSS برای UI، Socket.IO client برای چت زنده.
+- **Backend**: ASP.NET Core 8 Web API، SignalR برای چت real-time، EF Core 8 با PostgreSQL، Redis برای کش و rate limiting، Azure Blob/S3 برای فایل، Background services (Hangfire/Hosted Services) برای پردازش صف.
+- **AI Services**: Google Gemini APIs (`gemini-1.5-flash` برای moderation، `gemini-1.5-pro` + `text-embedding-004` برای RAG).
+- **Infrastructure**: Docker Compose برای dev، CI/CD (GitHub Actions)، Secrets از طریق Azure Key Vault/AWS Secrets Manager.
+
+---
+
+## 2. Domain & Data Design (Backend)
+
+1. **Entities**
+   - `Message`، `Attachment`, `ModerationLog`, `UserDiscipline`, `SupportKnowledgeItem`, `SupportQA`, `Appeal`, `RateLimitEntry`.
+2. **DB Schema Tasks**
+   - ایجاد migration اولیه با جداول و ایندکس مناسب (role_channel, event_id).
+   - افزودن ستون‌های JSON برای `moderation_reasons`, `retrieved_sources`.
+3. **Repositories/Services**
+   - MessageService (CRUD + paging + pinning).
+   - ModerationService (calls Gemini + rule engine).
+   - DisciplineService (score ledger + thresholds).
+   - SupportKnowledgeService (CRUD + search metadata).
+   - SupportChatService (retrieval + logging).
+4. **Vector Store**
+   - استفاده از pgvector یا Redis Stack. جدول `knowledge_vectors` با ستون برداری 1536.
+
+---
+
+## 3. Backend Feature Breakdown (.NET)
+
+### 3.1 Real-time Role Chats
+- SignalR Hub با گروه‌بندی بر اساس `role_channel` و `event_id`.
+- Middleware احراز هویت JWT + claim نقش.
+- API ها:
+  - `POST /api/chats/{role}/messages` (ارسال → صف moderation).
+  - `GET /api/chats/{role}/messages` (pagination، فیلتر event).
+  - `POST /api/chats/{role}/pins` (ادمین/مدیر نقش).
+- Queue (Azure Service Bus/RabbitMQ) برای پردازش async پیام و فراخوانی Gemini در BackgroundService.
+
+### 3.2 Moderation Pipeline
+- Rule Engine اولیه (کلمات ممنوع، لینک‌های blacklist).
+- سرویس Gemini Moderation:
+  - مدل Flash برای پیش‌فرض؛ اگر خروجی «Ambiguous»، دوباره با Pro.
+  - Mapping به سطوح اقدام (Publish/SoftWarn/Hold/Block).
+- ثبت `ModerationLog` + به‌روزرسانی `UserDiscipline`.
+- Webhook یا SignalR event برای اطلاع به کاربر (هشدار، بلاک).
+
+### 3.3 Appeals & Admin Controls
+- API ها برای لیست اعتراض‌ها، تغییر امتیاز، تنظیم Threshold.
+- Dashboard endpoints برای گزارش‌ها (Aggregations با LINQ/SQL).
+
+### 3.4 Support Chat (RAG)
+- API `POST /api/support/ask` → جریان Intent Detection + Retrieval + Generation.
+- ایندکس‌گذاری دانش با Background job (Parse PDFs → Text → Chunk → Embed → Store).
+- ذخیره `SupportQA` با منابع، confidence.
+- Endpoint مدیریت دانش: CRUD با role/event scoping.
+
+### 3.5 Rate Limiting & Anti-Abuse
+- Redis-based sliding window برای پیام‌ها.
+- Flood detector: الگوریتم بررسی تکرار پیام.
+- لینک‌چک با سرویس third-party یا لیست داخلی.
+
+### 3.6 Observability & Auditing
+- Serilog + OpenTelemetry (Tracing, Metrics).
+- Audit Trail middleware برای ثبت تغییرات ادمین و تصمیمات AI.
+
+---
+
+## 4. Frontend Feature Breakdown (Next.js)
+
+### 4.1 Global Chat UI
+- صفحات `/dashboard/[role]/chat` با App Router.
+- استفاده از Server Components برای داده اولیه و Client Components برای real-time.
+- بخش‌های UI:
+  - لیست گفتگو (virtualized list، نمایش status پیام).
+  - Composer با پشتیبانی Emoji، آپلود فایل (Dropzone + presigned URL).
+  - Badge نقش و امتیاز سلامت (discipline score).
+  - بنر سیاست محتوا و لینک اعتراض.
+- مدیریت state پیام‌های Pending/Held با optimistic updates + SignalR client.
+
+### 4.2 Moderation Feedback UX
+- Modal/Toast هشدار با توضیح AI.
+- صفحه `Policy & Appeals` برای مشاهده تاریخچه امتیاز منفی.
+- فرم اعتراض (calls `/api/appeals`).
+
+### 4.3 Support Chat UI
+- صفحه `/support` (دسترسی از سایدبار).
+- Chat-like experience با پیام سیستم/کاربر، نمایش منابع (chips لینک‌دار).
+- وضعیت اعتماد پاسخ (Confidence meter)، پیشنهاد escalate.
+
+### 4.4 Admin Panel Extensions
+- ماژول مدیریت دانش (editor با Markdown، آپلود فایل → indexing job).
+- تنظیم Thresholdها، مشاهده گزارش Heatmap و جدول تخلفات.
+- استفاده از React Query برای داده‌های مدیریتی.
+
+### 4.5 Localization & Accessibility
+- i18n با `next-intl` (فارسی/انگلیسی).
+- RTL پشتیبانی (Tailwind + CSS logical properties).
+- کیبورد ناوبری، ARIA labels.
+
+---
+
+## 5. DevOps & Environment Setup
+
+1. **Local Dev**
+   - Docker Compose: webapi, postgres, redis, vector-db, nextjs, traefik proxy.
+   - Seed scripts برای ایجاد نقش‌ها و داده نمونه.
+2. **CI/CD**
+   - GitHub Actions: build & test .NET، lint & test Next.js، امنیت (Dependabot, Snyk optional).
+   - Deployment به Azure Web App + Static Web App یا AWS (ECS + Amplify).
+3. **Secrets & Config**
+   - استفاده از User Secrets در dev، Key Vault در prod.
+   - ذخیره کلیدهای Gemini و Storage.
+4. **Monitoring**
+   - Application Insights/Datadog برای backend.
+   - Frontend logging با Sentry.
+
+---
+
+## 6. Milestones & Sprints (High-Level)
+
+### Sprint 1 (2 هفته)
+- Setup پروژه‌ها (.NET + Next.js + shared models).
+- طراحی DB و migrations.
+- پیاده‌سازی ابتدایی SignalR chat بدون moderation.
+- UI چت پایه (ارسال/دریافت).
+
+### Sprint 2
+- ادغام Gemini moderation pipeline + امتیاز انضباطی.
+- UI هشدارها، Appeals API & UI.
+- Rate limiting و audit logging.
+
+### Sprint 3
+- RAG pipeline: ingestion، embedding، پرسش و پاسخ.
+- UI چت پشتیبانی، مدیریت دانش ادمین.
+- گزارش‌ها و پنل مدیریتی.
+
+### Hardening (Post-Sprint)
+- تست امنیتی، بار، بهینه‌سازی latency.
+- مستندسازی و آموزش اپراتورها.
+
+---
+
+## 7. Acceptance Checklist
+
+- پیام‌ها قبل از انتشار توسط سرویس moderation بررسی و تصمیم ثبت می‌شود.
+- امتیاز انضباطی با Thresholdهای قابل تنظیم اعمال و قابل مشاهده است.
+- چت پشتیبانی حداقل 80٪ سوالات سناریوی آزمایشی را پاسخ می‌دهد و منابع را نشان می‌دهد.
+- ادمین می‌تواند سیاست‌ها، دانش‌پایه و اعتراض‌ها را مدیریت کند.
+- نرخ ارسال پیام، ترافیک moderation و گزارش‌ها در داشبورد قابل مشاهده است.
+


### PR DESCRIPTION
## Summary
- add ASP.NET Core web API for role-based chat moderation, support answers, and discipline tracking
- implement in-memory moderation pipeline, rate limiting, and knowledge-base responder stubs
- create Next.js dashboard with global chat client, support assistant UI, and project documentation

## Testing
- not run (tooling unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e13d1ab43c8329a42d7089fe7d47a1

## Summary by Sourcery

Provide a role-based moderated global chat and knowledge-driven support assistant via ASP.NET Core APIs and an RTL Next.js dashboard.

New Features:
- Add ChatController with endpoints for sending and retrieving role-specific messages integrated with a Gemini-based moderation pipeline and rate limiting.
- Add SupportController for knowledge-driven support queries using an in-memory knowledge base and simple token-overlap responder.
- Add DisciplineController and ModerationController for exposing user discipline scores and moderation logs.
- Create Next.js dashboard with global chat UI, support panel, role switcher, and navigation linking chat and support experiences.

Enhancements:
- Implement in-memory stores for messages, moderation logs, and user discipline tracking.
- Introduce a sliding-window rate limiter and discipline scoring service to enforce message quotas and penalties.
- Localize the frontend to RTL languages using Tailwind CSS and integrate informational status badges and feedback to users.

Documentation:
- Add implementation_plan.md detailing system architecture, domain design, and development roadmap.
- Include a README with setup instructions, API overview, and key feature descriptions.