### PR TITLE
Enable debug auth headers and update client auth handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# .NET build
+bin/
+obj/
+
+# Node
+node_modules/
+.next/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Env
+.env*
+
+# macOS
+.DS_Store
+/backend/NabTeams.Api/app.db
+/backend/NabTeams.Api/app.db-wal
+/backend/NabTeams.Api/app.db-shm

--- a/README.md
+++ b/README.md
@@ -1,0 +1,92 @@
+# NabTeams Conversational Platform
+
+این مخزن شامل بک‌اند ASP.NET Core (.NET 8) و فرانت‌اند Next.js 14 برای پیاده‌سازی «چت گلوبال نقش‌محور با پایش محتوایی Gemini»، «چت پشتیبانی دانشی مبتنی بر RAG»، «چرخهٔ انضباطی و امتیاز منفی» و «ماژول اعتراض» است. نسخهٔ حاضر به پایگاه‌داده PostgreSQL متصل می‌شود، احراز هویت SSO/JWT دارد و از Gemini برای Moderation/RAG (با قابلیت Fallback) بهره می‌گیرد.
+
+## ساختار مخزن
+
+```
+backend/                 # پروژه ASP.NET Core (Controllers + EF Core + Auth)
+frontend/                # اپ Next.js (App Router + NextAuth)
+implementation_plan.md   # سند تحلیل و طراحی اولیه
+```
+
+## متغیرهای محیطی کلیدی
+
+| نام | محل استفاده | توضیح |
+| --- | --- | --- |
+| `ConnectionStrings__DefaultConnection` | بک‌اند | رشته اتصال PostgreSQL (پیش‌فرض: `Host=localhost;Port=5432;Database=nabteams;Username=nabteams;Password=nabteams`) |
+| `Gemini__ApiKey` | بک‌اند | کلید دسترسی Google Gemini. در صورت خالی بودن، سرویس‌ها به حالت Rule-based برمی‌گردند. |
+| `Gemini__ModerationModel`, `Gemini__RagModel` | بک‌اند | نام مدل برای Moderation/RAG. پیش‌فرض: `gemini-1.5-pro`. |
+| `Authentication__Authority` | بک‌اند | آدرس سرور SSO/OIDC. |
+| `Authentication__Audience` | بک‌اند | Audience توکن JWT. |
+| `Authentication__AdminRole` | بک‌اند | نام نقش ادمین (پیش‌فرض `admin`). |
+| `Authentication__Disabled` | بک‌اند | اگر `true` باشد، احراز هویت غیرفعال می‌شود (برای توسعه محلی). |
+| `NEXTAUTH_URL` | فرانت‌اند | آدرس پابلیک اپ Next.js (مثلاً `http://localhost:3000`). |
+| `NEXTAUTH_SECRET` | فرانت‌اند | کلید رمزنگاری سشن NextAuth. |
+| `SSO_ISSUER`, `SSO_CLIENT_ID`, `SSO_CLIENT_SECRET`, `SSO_SCOPE` | فرانت‌اند | تنظیمات ارائه‌دهنده OIDC برای NextAuth. اگر مقداردهی نشود و `AUTH_ALLOW_DEV=true` باشد، ورود آزمایشی فعال می‌شود. |
+| `AUTH_ALLOW_DEV` | فرانت‌اند | در صورت `true` (پیش‌فرض)، Provider ورود آزمایشی (Credentials) فعال می‌شود. |
+| `NEXT_PUBLIC_API_URL` | فرانت‌اند | آدرس سرویس بک‌اند (پیش‌فرض `http://localhost:5000`). |
+
+## راه‌اندازی بک‌اند
+
+1. پیش‌نیازها: [Docker اختیاری برای PostgreSQL]، [.NET 8 SDK](https://dotnet.microsoft.com/download)، و سرویس PostgreSQL در حال اجرا.
+2. ایجاد پایگاه‌داده (نمونه):
+   ```bash
+   docker run --name nabteams-postgres -e POSTGRES_PASSWORD=nabteams -e POSTGRES_USER=nabteams -e POSTGRES_DB=nabteams -p 5432:5432 -d postgres:15
+   ```
+3. اجرای سرویس:
+   ```bash
+   cd backend/NabTeams.Api
+   dotnet restore
+   dotnet run --urls http://localhost:5000
+   ```
+4. اولین اجرا مهاجرت EF Core را اعمال و منابع اولیهٔ دانش را Seed می‌کند. مستندات Swagger در `http://localhost:5000/swagger` در دسترس است.
+
+### مهم‌ترین APIها
+
+- `POST /api/chat/{role}/messages` — ارسال پیام، پایش Gemini و اعمال امتیاز انضباطی.
+- `GET /api/chat/{role}/messages` — دریافت پیام‌های منتشرشده کانال (پیام‌های مسدود‌شده نمایش داده نمی‌شوند).
+- `GET /api/discipline/{role}/me` — مشاهده وضعیت امتیاز انضباطی کاربر جاری.
+- `POST /api/appeals` — ثبت اعتراض نسبت به پیام مسدود شده.
+- `GET /api/appeals` — فهرست اعتراض‌های کاربر.
+- `GET /api/appeals/admin` و `POST /api/appeals/{id}/decision` — بررسی و تصمیم‌گیری توسط ادمین.
+- `POST /api/support/query` — پاسخ دانشی (RAG) با Gemini.
+- `GET/POST/DELETE /api/knowledge-base` — مدیریت منابع دانش توسط ادمین.
+- `GET /api/moderation/{role}/logs` — مشاهده لاگ‌های پایش (ادمین).
+
+## راه‌اندازی فرانت‌اند
+
+1. پیش‌نیاز: [Node.js 18+](https://nodejs.org/)، متغیرهای محیطی NextAuth (حداقل `NEXTAUTH_SECRET`).
+2. نصب و اجرا:
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+3. اپلیکیشن در `http://localhost:3000` در دسترس است. برای استفاده از SSO باید متغیرهای `SSO_*` و `NEXTAUTH_URL` مقداردهی شود. در محیط توسعه می‌توانید از دکمه «ورود آزمایشی» استفاده کنید (`AUTH_ALLOW_DEV=true`).
+
+## قابلیت‌های کلیدی
+
+- **اتصال واقعی به Gemini:** `GeminiModerationService` و `SupportResponder` در صورت وجود `Gemini__ApiKey` درخواست ساختار‌یافته JSON به API رسمی می‌فرستند و در صورت خطا به Rule-based fallback می‌کنند.
+- **پایگاه‌داده پایدار:** تمام پیام‌ها، لاگ‌ها، امتیازات انضباطی، دانش و اعتراض‌ها در PostgreSQL ذخیره می‌شوند. مهاجرت‌ها به صورت خودکار هنگام اجرا اعمال می‌شوند.
+- **احراز هویت و مجوز:** بک‌اند با JWT Bearer از SSO سازمانی پشتیبانی می‌کند. مسیرهای ادمین با Policy `AdminOnly` محافظت شده‌اند. فرانت‌اند از NextAuth (OIDC) با امکان ورود آزمایشی بهره می‌گیرد.
+- **چرخهٔ انضباطی کامل:** هر پیام پایش شده، امتیاز منفی/مثبت را به‌روزرسانی می‌کند. وضعیت کاربر و تاریخچه رویدادها قابل استعلام است.
+- **ماژول اعتراض:** کاربران می‌توانند برای پیام‌های مسدود‌شده اعتراض ثبت کنند، و ادمین‌ها با فیلتر نقش/وضعیت بررسی و تایید/رد را ثبت می‌کنند.
+- **پشتیبانی دانشی RAG:** Gemini پاسخ را بر اساس منابع مدیریت‌شده توسط ادمین (به همراه Confidence و منابع استناد) تولید می‌کند. در نبود API Key الگوریتم رتبه‌بندی داخلی استفاده می‌شود.
+- **فرانت‌اند راست‌به‌چپ با نقش‌محوری:** داشبورد Next.js شامل مدیریت نقش، چت، پشتیبانی، مدیریت دانش و اعتراض‌ها است. جلسات NextAuth نقش‌های کاربر را به صورت Context در اختیار تمام اجزا قرار می‌دهد.
+
+## نکات توسعه
+
+- برای اجرا بدون SSO، مقدار `Authentication__Disabled=true` را در بک‌اند و `AUTH_ALLOW_DEV=true` را در فرانت‌اند قرار دهید تا ورود آزمایشی فعال شود.
+- در حالت غیرفعال بودن احراز هویت (`Authentication__Disabled=true`) فرانت‌اند به صورت خودکار شناسه، ایمیل و نقش‌های کاربر را از طریق هدرهای `X-Debug-User`، `X-Debug-Email` و `X-Debug-Roles` ارسال می‌کند تا API بتواند سیاست‌های نقش‌محور را اعمال کند.
+- جهت اتصال به سرویس Gemini، کلید سرویس را در `Gemini__ApiKey` قرار دهید. در صورت نیاز می‌توانید مدل‌ها را از طریق `Gemini__ModerationModel` و `Gemini__RagModel` تغییر دهید.
+- درخواست‌های API از فرانت‌اند همیشه توکن دسترسی NextAuth را در هدر `Authorization` ارسال می‌کنند؛ در حالت توسعه (بدون احراز هویت) بک‌اند نیز در حالت آزاد اجرا می‌شود.
+- نرخ محدودسازی پیام‌ها، نگاشت امتیاز و قوانین پایش در `GeminiModerationService` و `SlidingWindowRateLimiter` قابل تنظیم است.
+
+## تست و استقرار
+
+- برای اطمینان از پایداری پایگاه‌داده، اجرای دوره‌ای `dotnet ef migrations add` و `dotnet ef database update` (در محیط‌های غیرتوسعه) توصیه می‌شود.
+- پیشنهاد می‌شود متغیرهای محیطی در فایل `.env` (فرانت‌اند) و Secret Manager یا KeyVault (بک‌اند) نگهداری شوند.
+- هنگام استقرار فرانت‌اند، `NEXTAUTH_URL` باید آدرس نهایی (HTTPS) باشد تا تبادل سشن به درستی انجام گیرد.
+
+برای توسعه بیشتر می‌توانید به سند `implementation_plan.md` مراجعه کنید که ریزمعماری و جریان‌های فرایندی را شرح می‌دهد.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ implementation_plan.md   # سند تحلیل و طراحی اولیه
 
 - برای اجرا بدون SSO، مقدار `Authentication__Disabled=true` را در بک‌اند و `AUTH_ALLOW_DEV=true` را در فرانت‌اند قرار دهید تا ورود آزمایشی فعال شود.
 - در حالت غیرفعال بودن احراز هویت (`Authentication__Disabled=true`) فرانت‌اند به صورت خودکار شناسه، ایمیل و نقش‌های کاربر را از طریق هدرهای `X-Debug-User`، `X-Debug-Email` و `X-Debug-Roles` ارسال می‌کند تا API بتواند سیاست‌های نقش‌محور را اعمال کند.
+- برای اتصال real-time (SignalR) در همین حالت توسعه، همان داده‌ها از طریق Query String (`debug_user`، `debug_email`، `debug_roles`) نیز ارسال می‌شود تا هندشیک وب‌سوکت بدون نیاز به هدر سفارشی کار کند.
 - جهت اتصال به سرویس Gemini، کلید سرویس را در `Gemini__ApiKey` قرار دهید. در صورت نیاز می‌توانید مدل‌ها را از طریق `Gemini__ModerationModel` و `Gemini__RagModel` تغییر دهید.
 - درخواست‌های API از فرانت‌اند همیشه توکن دسترسی NextAuth را در هدر `Authorization` ارسال می‌کنند؛ در حالت توسعه (بدون احراز هویت) بک‌اند نیز در حالت آزاد اجرا می‌شود.
 - نرخ محدودسازی پیام‌ها، نگاشت امتیاز و قوانین پایش در `GeminiModerationService` و `SlidingWindowRateLimiter` قابل تنظیم است.

--- a/backend/NabTeams.Api/Configuration/AuthenticationSettings.cs
+++ b/backend/NabTeams.Api/Configuration/AuthenticationSettings.cs
@@ -1,0 +1,17 @@
+namespace NabTeams.Api.Configuration;
+
+public class AuthenticationSettings
+{
+    public bool Disabled { get; set; }
+    public string Authority { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public bool RequireHttpsMetadata { get; set; } = true;
+    public string AdminRole { get; set; } = "admin";
+    public string? NameClaimType { get; set; }
+    public string? RoleClaimType { get; set; }
+}
+
+public static class AuthorizationPolicies
+{
+    public const string Admin = "AdminOnly";
+}

--- a/backend/NabTeams.Api/Controllers/AppealsController.cs
+++ b/backend/NabTeams.Api/Controllers/AppealsController.cs
@@ -1,0 +1,157 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using NabTeams.Api.Configuration;
+using NabTeams.Api.Models;
+using NabTeams.Api.Services;
+using NabTeams.Api.Stores;
+
+namespace NabTeams.Api.Controllers;
+
+[ApiController]
+[Route("api/appeals")]
+[Authorize]
+public class AppealsController : ControllerBase
+{
+    private readonly IAppealStore _appealStore;
+    private readonly IChatRepository _chatRepository;
+    private readonly IModerationLogStore _moderationLogStore;
+    private readonly string _adminRole;
+
+    public AppealsController(
+        IAppealStore appealStore,
+        IChatRepository chatRepository,
+        IModerationLogStore moderationLogStore,
+        IOptions<AuthenticationSettings> authOptions)
+    {
+        _appealStore = appealStore;
+        _chatRepository = chatRepository;
+        _moderationLogStore = moderationLogStore;
+        _adminRole = authOptions.Value.AdminRole;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyCollection<Appeal>>> GetMineAsync(CancellationToken cancellationToken)
+    {
+        var userId = GetUserId();
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Forbid();
+        }
+
+        var appeals = await _appealStore.GetForUserAsync(userId, cancellationToken);
+        return Ok(appeals);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Appeal>> CreateAsync([FromBody] CreateAppealRequest request, CancellationToken cancellationToken)
+    {
+        if (request.MessageId == Guid.Empty || string.IsNullOrWhiteSpace(request.Reason))
+        {
+            return BadRequest("شناسه پیام و دلیل اعتراض الزامی است.");
+        }
+
+        var userId = GetUserId();
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Forbid();
+        }
+
+        var message = await _chatRepository.GetMessageAsync(request.MessageId, cancellationToken);
+        var log = message is null
+            ? await _moderationLogStore.GetAsync(request.MessageId, cancellationToken)
+            : null;
+
+        if (message is null && log is null)
+        {
+            return NotFound("پیام موردنظر یافت نشد.");
+        }
+
+        var channel = message?.Channel ?? log!.Channel;
+        var ownerId = message?.SenderUserId ?? log!.UserId;
+        if (!string.Equals(ownerId, userId, StringComparison.Ordinal) && !IsAdmin())
+        {
+            return Forbid();
+        }
+
+        var appeal = new Appeal
+        {
+            MessageId = request.MessageId,
+            Channel = channel,
+            UserId = ownerId,
+            Reason = request.Reason.Trim(),
+            SubmittedAt = DateTimeOffset.UtcNow,
+            Status = AppealStatus.Pending
+        };
+
+        try
+        {
+            var created = await _appealStore.CreateAsync(appeal, cancellationToken);
+            return CreatedAtAction(nameof(GetMineAsync), new { id = created.Id }, created);
+        }
+        catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or InvalidOperationException)
+        {
+            return Conflict("برای این پیام قبلاً اعتراض ثبت شده است.");
+        }
+    }
+
+    [HttpGet("admin")]
+    [Authorize(Policy = AuthorizationPolicies.Admin)]
+    public async Task<ActionResult<IReadOnlyCollection<Appeal>>> QueryAsync([FromQuery] string? role, [FromQuery] AppealStatus? status, CancellationToken cancellationToken)
+    {
+        RoleChannel? channel = null;
+        if (!string.IsNullOrWhiteSpace(role))
+        {
+            if (!RoleChannelExtensions.TryParse(role, out var parsed))
+            {
+                return BadRequest("نقش نامعتبر است.");
+            }
+
+            channel = parsed;
+        }
+
+        var appeals = await _appealStore.QueryAsync(channel, status, cancellationToken);
+        return Ok(appeals);
+    }
+
+    [HttpPost("{id:guid}/decision")]
+    [Authorize(Policy = AuthorizationPolicies.Admin)]
+    public async Task<ActionResult<Appeal>> ResolveAsync(Guid id, [FromBody] AppealDecisionRequest request, CancellationToken cancellationToken)
+    {
+        if (request.Status == AppealStatus.Pending)
+        {
+            return BadRequest("وضعیت باید پذیرفته شده یا رد شده باشد.");
+        }
+
+        var reviewerId = GetUserId() ?? "system";
+        var resolved = await _appealStore.ResolveAsync(id, request.Status, reviewerId, request.Notes, cancellationToken);
+        if (resolved is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(resolved);
+    }
+
+    private string? GetUserId()
+    {
+        return User.FindFirstValue("sub")
+               ?? User.FindFirstValue(ClaimTypes.NameIdentifier)
+               ?? User.Identity?.Name;
+    }
+
+    private bool IsAdmin()
+    {
+        if (User.IsInRole(_adminRole))
+        {
+            return true;
+        }
+
+        var normalizedAdmin = _adminRole.ToLowerInvariant();
+        return User.Claims
+            .Where(c => c.Type == ClaimTypes.Role || c.Type.Equals("role", StringComparison.OrdinalIgnoreCase) || c.Type.Equals("roles", StringComparison.OrdinalIgnoreCase))
+            .Select(c => c.Value.ToLowerInvariant())
+            .Contains(normalizedAdmin);
+    }
+}

--- a/backend/NabTeams.Api/Controllers/ChatController.cs
+++ b/backend/NabTeams.Api/Controllers/ChatController.cs
@@ -15,25 +15,19 @@ namespace NabTeams.Api.Controllers;
 public class ChatController : ControllerBase
 {
     private readonly IChatRepository _chatRepository;
-    private readonly IModerationService _moderationService;
-    private readonly IModerationLogStore _moderationLogStore;
-    private readonly IUserDisciplineStore _userDisciplineStore;
     private readonly IRateLimiter _rateLimiter;
+    private readonly IChatModerationQueue _moderationQueue;
     private readonly string _adminRole;
 
     public ChatController(
         IChatRepository chatRepository,
-        IModerationService moderationService,
-        IModerationLogStore moderationLogStore,
-        IUserDisciplineStore userDisciplineStore,
         IRateLimiter rateLimiter,
+        IChatModerationQueue moderationQueue,
         IOptions<AuthenticationSettings> authOptions)
     {
         _chatRepository = chatRepository;
-        _moderationService = moderationService;
-        _moderationLogStore = moderationLogStore;
-        _userDisciplineStore = userDisciplineStore;
         _rateLimiter = rateLimiter;
+        _moderationQueue = moderationQueue;
         _adminRole = authOptions.Value.AdminRole;
     }
 
@@ -94,65 +88,33 @@ public class ChatController : ControllerBase
             });
         }
 
-        var candidate = new MessageCandidate(userId, channel, request.Content);
-        var moderation = await _moderationService.ModerateAsync(candidate, cancellationToken);
-
-        var status = moderation.Decision switch
-        {
-            ModerationDecision.Publish or ModerationDecision.SoftWarn => MessageStatus.Published,
-            ModerationDecision.Hold => MessageStatus.Held,
-            _ => MessageStatus.Blocked
-        };
-
         var message = new Message
         {
             Channel = channel,
             SenderUserId = userId,
             Content = request.Content,
-            Status = status,
-            ModerationRisk = moderation.RiskScore,
-            ModerationTags = moderation.PolicyTags,
-            ModerationNotes = moderation.Notes,
-            PenaltyPoints = moderation.PenaltyPoints
+            Status = MessageStatus.Held,
+            ModerationRisk = 0,
+            ModerationTags = Array.Empty<string>(),
+            ModerationNotes = "در انتظار بررسی خودکار توسط Gemini.",
+            PenaltyPoints = 0
         };
 
         await _chatRepository.AddMessageAsync(message, cancellationToken);
-
-        var log = new ModerationLog
-        {
-            MessageId = message.Id,
-            UserId = userId,
-            Channel = channel,
-            RiskScore = moderation.RiskScore,
-            PolicyTags = moderation.PolicyTags,
-            ActionTaken = moderation.Decision.ToString(),
-            PenaltyPoints = moderation.PenaltyPoints
-        };
-        await _moderationLogStore.AddAsync(log, cancellationToken);
-
-        if (moderation.PenaltyPoints != 0)
-        {
-            await _userDisciplineStore.UpdateScoreAsync(userId, channel, -moderation.PenaltyPoints, moderation.Notes, message.Id, cancellationToken);
-        }
+        await _moderationQueue.EnqueueAsync(new ChatModerationWorkItem(message.Id, userId, channel, request.Content), cancellationToken);
 
         var response = new SendMessageResponse
         {
             MessageId = message.Id,
-            Status = status,
-            ModerationRisk = moderation.RiskScore,
-            ModerationTags = moderation.PolicyTags,
-            ModerationNotes = moderation.Notes,
-            PenaltyPoints = moderation.PenaltyPoints,
-            SoftWarn = moderation.Decision == ModerationDecision.SoftWarn
+            Status = MessageStatus.Held,
+            ModerationRisk = 0,
+            ModerationTags = Array.Empty<string>(),
+            ModerationNotes = message.ModerationNotes,
+            PenaltyPoints = 0,
+            SoftWarn = false
         };
 
-        return moderation.Decision switch
-        {
-            ModerationDecision.Publish or ModerationDecision.SoftWarn => Ok(response),
-            ModerationDecision.Hold => StatusCode(StatusCodes.Status202Accepted, response),
-            ModerationDecision.Block or ModerationDecision.BlockAndReport => StatusCode(StatusCodes.Status403Forbidden, response),
-            _ => Ok(response)
-        };
+        return StatusCode(StatusCodes.Status202Accepted, response);
     }
 
     private string? GetUserId()

--- a/backend/NabTeams.Api/Controllers/ChatController.cs
+++ b/backend/NabTeams.Api/Controllers/ChatController.cs
@@ -1,0 +1,193 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using NabTeams.Api.Configuration;
+using NabTeams.Api.Models;
+using NabTeams.Api.Services;
+using NabTeams.Api.Stores;
+
+namespace NabTeams.Api.Controllers;
+
+[ApiController]
+[Route("api/chat")]
+[Authorize]
+public class ChatController : ControllerBase
+{
+    private readonly IChatRepository _chatRepository;
+    private readonly IModerationService _moderationService;
+    private readonly IModerationLogStore _moderationLogStore;
+    private readonly IUserDisciplineStore _userDisciplineStore;
+    private readonly IRateLimiter _rateLimiter;
+    private readonly string _adminRole;
+
+    public ChatController(
+        IChatRepository chatRepository,
+        IModerationService moderationService,
+        IModerationLogStore moderationLogStore,
+        IUserDisciplineStore userDisciplineStore,
+        IRateLimiter rateLimiter,
+        IOptions<AuthenticationSettings> authOptions)
+    {
+        _chatRepository = chatRepository;
+        _moderationService = moderationService;
+        _moderationLogStore = moderationLogStore;
+        _userDisciplineStore = userDisciplineStore;
+        _rateLimiter = rateLimiter;
+        _adminRole = authOptions.Value.AdminRole;
+    }
+
+    [HttpGet("{role}/messages")]
+    public async Task<ActionResult<MessagesResponse>> GetMessagesAsync(string role, CancellationToken cancellationToken)
+    {
+        if (!RoleChannelExtensions.TryParse(role, out var channel))
+        {
+            return BadRequest("نقش نامعتبر است.");
+        }
+
+        if (!HasChannelAccess(channel))
+        {
+            return Forbid();
+        }
+
+        var messages = await _chatRepository.GetMessagesAsync(channel, cancellationToken);
+        return Ok(new MessagesResponse { Messages = messages });
+    }
+
+    [HttpPost("{role}/messages")]
+    public async Task<ActionResult<SendMessageResponse>> SendMessageAsync(string role, [FromBody] SendMessageRequest request, CancellationToken cancellationToken)
+    {
+        if (!RoleChannelExtensions.TryParse(role, out var channel))
+        {
+            return BadRequest("نقش نامعتبر است.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Content))
+        {
+            return BadRequest("متن پیام الزامی است.");
+        }
+
+        if (!HasChannelAccess(channel))
+        {
+            return Forbid();
+        }
+
+        var userId = GetUserId();
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Forbid();
+        }
+
+        var rateResult = _rateLimiter.CheckQuota(userId, channel);
+        if (!rateResult.Allowed)
+        {
+            return StatusCode(429, new SendMessageResponse
+            {
+                MessageId = Guid.Empty,
+                Status = MessageStatus.Blocked,
+                ModerationRisk = 0,
+                ModerationTags = Array.Empty<string>(),
+                ModerationNotes = rateResult.Message,
+                PenaltyPoints = 0,
+                SoftWarn = false,
+                RateLimitMessage = rateResult.Message
+            });
+        }
+
+        var candidate = new MessageCandidate(userId, channel, request.Content);
+        var moderation = await _moderationService.ModerateAsync(candidate, cancellationToken);
+
+        var status = moderation.Decision switch
+        {
+            ModerationDecision.Publish or ModerationDecision.SoftWarn => MessageStatus.Published,
+            ModerationDecision.Hold => MessageStatus.Held,
+            _ => MessageStatus.Blocked
+        };
+
+        var message = new Message
+        {
+            Channel = channel,
+            SenderUserId = userId,
+            Content = request.Content,
+            Status = status,
+            ModerationRisk = moderation.RiskScore,
+            ModerationTags = moderation.PolicyTags,
+            ModerationNotes = moderation.Notes,
+            PenaltyPoints = moderation.PenaltyPoints
+        };
+
+        await _chatRepository.AddMessageAsync(message, cancellationToken);
+
+        var log = new ModerationLog
+        {
+            MessageId = message.Id,
+            UserId = userId,
+            Channel = channel,
+            RiskScore = moderation.RiskScore,
+            PolicyTags = moderation.PolicyTags,
+            ActionTaken = moderation.Decision.ToString(),
+            PenaltyPoints = moderation.PenaltyPoints
+        };
+        await _moderationLogStore.AddAsync(log, cancellationToken);
+
+        if (moderation.PenaltyPoints != 0)
+        {
+            await _userDisciplineStore.UpdateScoreAsync(userId, channel, -moderation.PenaltyPoints, moderation.Notes, message.Id, cancellationToken);
+        }
+
+        var response = new SendMessageResponse
+        {
+            MessageId = message.Id,
+            Status = status,
+            ModerationRisk = moderation.RiskScore,
+            ModerationTags = moderation.PolicyTags,
+            ModerationNotes = moderation.Notes,
+            PenaltyPoints = moderation.PenaltyPoints,
+            SoftWarn = moderation.Decision == ModerationDecision.SoftWarn
+        };
+
+        return moderation.Decision switch
+        {
+            ModerationDecision.Publish or ModerationDecision.SoftWarn => Ok(response),
+            ModerationDecision.Hold => StatusCode(StatusCodes.Status202Accepted, response),
+            ModerationDecision.Block or ModerationDecision.BlockAndReport => StatusCode(StatusCodes.Status403Forbidden, response),
+            _ => Ok(response)
+        };
+    }
+
+    private string? GetUserId()
+    {
+        return User.FindFirstValue("sub")
+               ?? User.FindFirstValue(ClaimTypes.NameIdentifier)
+               ?? User.Identity?.Name;
+    }
+
+    private bool HasChannelAccess(RoleChannel channel)
+    {
+        if (IsAdmin())
+        {
+            return true;
+        }
+
+        var normalized = channel.ToString().ToLowerInvariant();
+        var roleClaims = User.Claims
+            .Where(c => c.Type == ClaimTypes.Role || c.Type.Equals("role", StringComparison.OrdinalIgnoreCase) || c.Type.Equals("roles", StringComparison.OrdinalIgnoreCase))
+            .Select(c => c.Value.ToLowerInvariant());
+
+        return roleClaims.Contains(normalized);
+    }
+
+    private bool IsAdmin()
+    {
+        if (User.IsInRole(_adminRole))
+        {
+            return true;
+        }
+
+        var normalizedAdmin = _adminRole.ToLowerInvariant();
+        return User.Claims
+            .Where(c => c.Type == ClaimTypes.Role || c.Type.Equals("role", StringComparison.OrdinalIgnoreCase) || c.Type.Equals("roles", StringComparison.OrdinalIgnoreCase))
+            .Select(c => c.Value.ToLowerInvariant())
+            .Contains(normalizedAdmin);
+    }
+}

--- a/backend/NabTeams.Api/Controllers/DisciplineController.cs
+++ b/backend/NabTeams.Api/Controllers/DisciplineController.cs
@@ -1,0 +1,69 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using NabTeams.Api.Configuration;
+using NabTeams.Api.Models;
+using NabTeams.Api.Stores;
+
+namespace NabTeams.Api.Controllers;
+
+[ApiController]
+[Route("api/discipline")]
+[Authorize]
+public class DisciplineController : ControllerBase
+{
+    private readonly IUserDisciplineStore _disciplineStore;
+
+    public DisciplineController(IUserDisciplineStore disciplineStore)
+    {
+        _disciplineStore = disciplineStore;
+    }
+
+    [HttpGet("{role}/me")]
+    public async Task<ActionResult<UserDiscipline>> GetForCurrentAsync(string role, CancellationToken cancellationToken)
+    {
+        if (!RoleChannelExtensions.TryParse(role, out var channel))
+        {
+            return BadRequest("نقش نامعتبر است.");
+        }
+
+        var userId = GetUserId();
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Forbid();
+        }
+
+        var record = await _disciplineStore.GetAsync(userId, channel, cancellationToken);
+        if (record is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(record);
+    }
+
+    [HttpGet("{role}/{userId}")]
+    [Authorize(Policy = AuthorizationPolicies.Admin)]
+    public async Task<ActionResult<UserDiscipline>> GetAsync(string role, string userId, CancellationToken cancellationToken)
+    {
+        if (!RoleChannelExtensions.TryParse(role, out var channel))
+        {
+            return BadRequest("نقش نامعتبر است.");
+        }
+
+        var record = await _disciplineStore.GetAsync(userId, channel, cancellationToken);
+        if (record is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(record);
+    }
+
+    private string? GetUserId()
+    {
+        return User.FindFirstValue("sub")
+               ?? User.FindFirstValue(ClaimTypes.NameIdentifier)
+               ?? User.Identity?.Name;
+    }
+}

--- a/backend/NabTeams.Api/Controllers/KnowledgeBaseController.cs
+++ b/backend/NabTeams.Api/Controllers/KnowledgeBaseController.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using NabTeams.Api.Configuration;
+using NabTeams.Api.Models;
+using NabTeams.Api.Services;
+
+namespace NabTeams.Api.Controllers;
+
+[ApiController]
+[Route("api/knowledge-base")]
+[Authorize]
+public class KnowledgeBaseController : ControllerBase
+{
+    private readonly ISupportKnowledgeBase _knowledgeBase;
+
+    public KnowledgeBaseController(ISupportKnowledgeBase knowledgeBase)
+    {
+        _knowledgeBase = knowledgeBase;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyCollection<KnowledgeBaseItem>>> GetAsync(CancellationToken cancellationToken)
+    {
+        var items = await _knowledgeBase.GetAllAsync(cancellationToken);
+        return Ok(items);
+    }
+
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicies.Admin)]
+    public async Task<ActionResult<KnowledgeBaseItem>> UpsertAsync([FromBody] KnowledgeBaseUpsertRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Title) || string.IsNullOrWhiteSpace(request.Body))
+        {
+            return BadRequest("عنوان و متن منبع الزامی است.");
+        }
+
+        var item = new KnowledgeBaseItem
+        {
+            Id = string.IsNullOrWhiteSpace(request.Id) ? Guid.NewGuid().ToString() : request.Id,
+            Title = request.Title.Trim(),
+            Body = request.Body.Trim(),
+            Audience = string.IsNullOrWhiteSpace(request.Audience) ? "all" : request.Audience.Trim().ToLowerInvariant(),
+            Tags = request.Tags?.Select(t => t.Trim()).Where(t => !string.IsNullOrEmpty(t)).ToList() ?? new List<string>(),
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        var stored = await _knowledgeBase.UpsertAsync(item, cancellationToken);
+        return Ok(stored);
+    }
+
+    [HttpDelete("{id}")]
+    [Authorize(Policy = AuthorizationPolicies.Admin)]
+    public async Task<IActionResult> DeleteAsync(string id, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return BadRequest("شناسه نامعتبر است.");
+        }
+
+        await _knowledgeBase.DeleteAsync(id, cancellationToken);
+        return NoContent();
+    }
+}

--- a/backend/NabTeams.Api/Controllers/ModerationController.cs
+++ b/backend/NabTeams.Api/Controllers/ModerationController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using NabTeams.Api.Configuration;
+using NabTeams.Api.Models;
+using NabTeams.Api.Stores;
+
+namespace NabTeams.Api.Controllers;
+
+[ApiController]
+[Route("api/moderation")]
+[Authorize(Policy = AuthorizationPolicies.Admin)]
+public class ModerationController : ControllerBase
+{
+    private readonly IModerationLogStore _logStore;
+
+    public ModerationController(IModerationLogStore logStore)
+    {
+        _logStore = logStore;
+    }
+
+    [HttpGet("{role}/logs")]
+    public async Task<ActionResult<IReadOnlyCollection<ModerationLog>>> GetLogsAsync(string role, CancellationToken cancellationToken)
+    {
+        if (!RoleChannelExtensions.TryParse(role, out var channel))
+        {
+            return BadRequest("نقش نامعتبر است.");
+        }
+
+        var logs = await _logStore.QueryAsync(channel, cancellationToken);
+        return Ok(logs);
+    }
+}

--- a/backend/NabTeams.Api/Controllers/SupportController.cs
+++ b/backend/NabTeams.Api/Controllers/SupportController.cs
@@ -1,0 +1,49 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using NabTeams.Api.Models;
+using NabTeams.Api.Services;
+
+namespace NabTeams.Api.Controllers;
+
+[ApiController]
+[Route("api/support")]
+[Authorize]
+public class SupportController : ControllerBase
+{
+    private readonly ISupportResponder _responder;
+
+    public SupportController(ISupportResponder responder)
+    {
+        _responder = responder;
+    }
+
+    [HttpPost("query")]
+    public async Task<ActionResult<SupportAnswer>> QueryAsync([FromBody] SupportQuery query, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(query.Question))
+        {
+            return BadRequest("سوال الزامی است.");
+        }
+
+        var role = string.IsNullOrWhiteSpace(query.Role) ? ResolveRoleFromClaims() : query.Role;
+        var normalizedQuery = new SupportQuery
+        {
+            Question = query.Question,
+            Role = string.IsNullOrWhiteSpace(role) ? "all" : role!
+        };
+
+        var answer = await _responder.GetAnswerAsync(normalizedQuery, cancellationToken);
+        return Ok(answer);
+    }
+
+    private string? ResolveRoleFromClaims()
+    {
+        var roles = User.Claims
+            .Where(c => c.Type == ClaimTypes.Role || c.Type.Equals("role", StringComparison.OrdinalIgnoreCase) || c.Type.Equals("roles", StringComparison.OrdinalIgnoreCase))
+            .Select(c => c.Value.ToLowerInvariant())
+            .Where(value => !string.Equals(value, "admin", StringComparison.OrdinalIgnoreCase));
+
+        return roles.FirstOrDefault();
+    }
+}

--- a/backend/NabTeams.Api/Data/ApplicationDbContext.cs
+++ b/backend/NabTeams.Api/Data/ApplicationDbContext.cs
@@ -1,0 +1,178 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Data;
+
+public class ApplicationDbContext : DbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<MessageEntity> Messages => Set<MessageEntity>();
+    public DbSet<ModerationLogEntity> ModerationLogs => Set<ModerationLogEntity>();
+    public DbSet<UserDisciplineEntity> UserDisciplines => Set<UserDisciplineEntity>();
+    public DbSet<DisciplineEventEntity> DisciplineEvents => Set<DisciplineEventEntity>();
+    public DbSet<KnowledgeBaseItemEntity> KnowledgeBaseItems => Set<KnowledgeBaseItemEntity>();
+    public DbSet<AppealEntity> Appeals => Set<AppealEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        var channelConverter = new EnumToStringConverter<RoleChannel>();
+        var statusConverter = new EnumToStringConverter<MessageStatus>();
+        var appealStatusConverter = new EnumToStringConverter<AppealStatus>();
+
+        var stringListComparer = new ValueComparer<List<string>>(
+            (left, right) => (left ?? new()).SequenceEqual(right ?? new()),
+            list => (list ?? new()).Aggregate(0, (hash, item) => HashCode.Combine(hash, item.GetHashCode())),
+            list => (list ?? new()).ToList());
+
+        modelBuilder.Entity<MessageEntity>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Channel).HasConversion(channelConverter).IsRequired();
+            entity.Property(e => e.Status).HasConversion(statusConverter).IsRequired();
+            entity.Property(e => e.SenderUserId).HasMaxLength(128).IsRequired();
+            entity.Property(e => e.Content).IsRequired();
+            entity.Property(e => e.ModerationTags)
+                .HasConversion(
+                    list => string.Join('\u001F', list ?? new()),
+                    value => string.IsNullOrWhiteSpace(value)
+                        ? new List<string>()
+                        : value.Split('\u001F', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList())
+                .Metadata.SetValueComparer(stringListComparer);
+        });
+
+        modelBuilder.Entity<ModerationLogEntity>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Channel).HasConversion(channelConverter).IsRequired();
+            entity.Property(e => e.UserId).HasMaxLength(128).IsRequired();
+            entity.Property(e => e.PolicyTags)
+                .HasConversion(
+                    list => string.Join('\u001F', list ?? new()),
+                    value => string.IsNullOrWhiteSpace(value)
+                        ? new List<string>()
+                        : value.Split('\u001F', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList())
+                .Metadata.SetValueComparer(stringListComparer);
+        });
+
+        modelBuilder.Entity<UserDisciplineEntity>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.UserId).HasMaxLength(128).IsRequired();
+            entity.Property(e => e.Channel).HasConversion(channelConverter).IsRequired();
+            entity.HasIndex(e => new { e.UserId, e.Channel }).IsUnique();
+            entity.HasMany(e => e.Events)
+                .WithOne(e => e.UserDiscipline)
+                .HasForeignKey(e => e.UserDisciplineId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<DisciplineEventEntity>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Reason).HasMaxLength(256);
+        });
+
+        modelBuilder.Entity<KnowledgeBaseItemEntity>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Audience).HasMaxLength(32).IsRequired();
+            entity.Property(e => e.Title).HasMaxLength(256).IsRequired();
+            entity.Property(e => e.Tags)
+                .HasConversion(
+                    list => string.Join('\u001F', list ?? new()),
+                    value => string.IsNullOrWhiteSpace(value)
+                        ? new List<string>()
+                        : value.Split('\u001F', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList())
+                .Metadata.SetValueComparer(stringListComparer);
+        });
+
+        modelBuilder.Entity<AppealEntity>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Channel).HasConversion(channelConverter).IsRequired();
+            entity.Property(e => e.Status).HasConversion(appealStatusConverter).IsRequired();
+            entity.Property(e => e.UserId).HasMaxLength(128).IsRequired();
+            entity.Property(e => e.Reason).HasMaxLength(512).IsRequired();
+            entity.HasIndex(e => new { e.MessageId, e.UserId }).IsUnique();
+        });
+    }
+}
+
+public class MessageEntity
+{
+    public Guid Id { get; set; }
+    public RoleChannel Channel { get; set; }
+    public string SenderUserId { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; }
+    public MessageStatus Status { get; set; }
+    public double ModerationRisk { get; set; }
+    public List<string> ModerationTags { get; set; } = new();
+    public string? ModerationNotes { get; set; }
+    public int PenaltyPoints { get; set; }
+}
+
+public class ModerationLogEntity
+{
+    public Guid Id { get; set; }
+    public Guid MessageId { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public RoleChannel Channel { get; set; }
+    public double RiskScore { get; set; }
+    public List<string> PolicyTags { get; set; } = new();
+    public string ActionTaken { get; set; } = string.Empty;
+    public int PenaltyPoints { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+}
+
+public class UserDisciplineEntity
+{
+    public Guid Id { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public RoleChannel Channel { get; set; }
+    public int ScoreBalance { get; set; }
+    public List<DisciplineEventEntity> Events { get; set; } = new();
+}
+
+public class DisciplineEventEntity
+{
+    public Guid Id { get; set; }
+    public Guid UserDisciplineId { get; set; }
+    public UserDisciplineEntity? UserDiscipline { get; set; }
+    public DateTimeOffset OccurredAt { get; set; }
+    public string Reason { get; set; } = string.Empty;
+    public int Delta { get; set; }
+    public Guid MessageId { get; set; }
+}
+
+public class KnowledgeBaseItemEntity
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Title { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+    public string Audience { get; set; } = "all";
+    public List<string> Tags { get; set; } = new();
+    public DateTimeOffset UpdatedAt { get; set; }
+}
+
+public class AppealEntity
+{
+    public Guid Id { get; set; }
+    public Guid MessageId { get; set; }
+    public RoleChannel Channel { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public DateTimeOffset SubmittedAt { get; set; }
+    public string Reason { get; set; } = string.Empty;
+    public AppealStatus Status { get; set; }
+    public string? ResolutionNotes { get; set; }
+    public string? ReviewedBy { get; set; }
+    public DateTimeOffset? ReviewedAt { get; set; }
+}

--- a/backend/NabTeams.Api/Data/DatabaseInitializer.cs
+++ b/backend/NabTeams.Api/Data/DatabaseInitializer.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace NabTeams.Api.Data;
+
+public static class DatabaseInitializer
+{
+    public static async Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    {
+        using var scope = services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        await context.Database.MigrateAsync(cancellationToken);
+
+        if (!await context.KnowledgeBaseItems.AnyAsync(cancellationToken))
+        {
+            context.KnowledgeBaseItems.AddRange(new[]
+            {
+                new KnowledgeBaseItemEntity
+                {
+                    Id = "event-rules",
+                    Title = "قوانین کلی رویداد",
+                    Body = "شرکت‌کنندگان باید قوانین اخلاقی و حرفه‌ای را رعایت کنند. ساعات برگزاری از 9 تا 18 می‌باشد.",
+                    Audience = "participant",
+                    Tags = new List<string> { "rules", "schedule" },
+                    UpdatedAt = DateTimeOffset.UtcNow
+                },
+                new KnowledgeBaseItemEntity
+                {
+                    Id = "mentor-support",
+                    Title = "نقش منتورها",
+                    Body = "منتورها می‌توانند از طریق داشبورد منتور مستقیماً با تیم‌ها گفتگو کنند و دسترسی به اتاق‌های منتورینگ دارند.",
+                    Audience = "mentor",
+                    Tags = new List<string> { "mentor", "access" },
+                    UpdatedAt = DateTimeOffset.UtcNow
+                },
+                new KnowledgeBaseItemEntity
+                {
+                    Id = "contact-admin",
+                    Title = "راه‌های ارتباطی با ادمین",
+                    Body = "برای مسائل اضطراری با شماره 021-000000 تماس بگیرید یا از فرم تیکت در داشبورد استفاده کنید.",
+                    Audience = "all",
+                    Tags = new List<string> { "contact", "support" },
+                    UpdatedAt = DateTimeOffset.UtcNow
+                },
+                new KnowledgeBaseItemEntity
+                {
+                    Id = "investor-brief",
+                    Title = "دسترسی سرمایه‌گذاران",
+                    Body = "سرمایه‌گذاران به داشبورد ارزیابی مالی و گزارش‌های تیم‌ها دسترسی دارند. نسخه به‌روزشده هر روز ساعت 12 منتشر می‌شود.",
+                    Audience = "investor",
+                    Tags = new List<string> { "investor", "reports" },
+                    UpdatedAt = DateTimeOffset.UtcNow
+                }
+            });
+
+            await context.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/backend/NabTeams.Api/Data/EntityMappingExtensions.cs
+++ b/backend/NabTeams.Api/Data/EntityMappingExtensions.cs
@@ -1,0 +1,139 @@
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Data;
+
+public static class EntityMappingExtensions
+{
+    public static Message ToModel(this MessageEntity entity)
+        => new()
+        {
+            Id = entity.Id,
+            Channel = entity.Channel,
+            SenderUserId = entity.SenderUserId,
+            Content = entity.Content,
+            CreatedAt = entity.CreatedAt,
+            Status = entity.Status,
+            ModerationRisk = entity.ModerationRisk,
+            ModerationTags = entity.ModerationTags.ToList(),
+            ModerationNotes = entity.ModerationNotes,
+            PenaltyPoints = entity.PenaltyPoints
+        };
+
+    public static MessageEntity ToEntity(this Message model)
+        => new()
+        {
+            Id = model.Id,
+            Channel = model.Channel,
+            SenderUserId = model.SenderUserId,
+            Content = model.Content,
+            CreatedAt = model.CreatedAt,
+            Status = model.Status,
+            ModerationRisk = model.ModerationRisk,
+            ModerationTags = model.ModerationTags.ToList(),
+            ModerationNotes = model.ModerationNotes,
+            PenaltyPoints = model.PenaltyPoints
+        };
+
+    public static ModerationLog ToModel(this ModerationLogEntity entity)
+        => new()
+        {
+            Id = entity.Id,
+            MessageId = entity.MessageId,
+            UserId = entity.UserId,
+            Channel = entity.Channel,
+            RiskScore = entity.RiskScore,
+            PolicyTags = entity.PolicyTags.ToList(),
+            ActionTaken = entity.ActionTaken,
+            PenaltyPoints = entity.PenaltyPoints,
+            CreatedAt = entity.CreatedAt
+        };
+
+    public static ModerationLogEntity ToEntity(this ModerationLog model)
+        => new()
+        {
+            Id = model.Id,
+            MessageId = model.MessageId,
+            UserId = model.UserId,
+            Channel = model.Channel,
+            RiskScore = model.RiskScore,
+            PolicyTags = model.PolicyTags.ToList(),
+            ActionTaken = model.ActionTaken,
+            PenaltyPoints = model.PenaltyPoints,
+            CreatedAt = model.CreatedAt
+        };
+
+    public static UserDiscipline ToModel(this UserDisciplineEntity entity)
+    {
+        var record = new UserDiscipline
+        {
+            UserId = entity.UserId,
+            Channel = entity.Channel,
+            ScoreBalance = entity.ScoreBalance
+        };
+
+        var orderedEvents = entity.Events
+            .OrderByDescending(e => e.OccurredAt)
+            .Select(e => new DisciplineEvent
+            {
+                MessageId = e.MessageId,
+                Delta = e.Delta,
+                OccurredAt = e.OccurredAt,
+                Reason = e.Reason
+            });
+
+        record.History.AddRange(orderedEvents);
+        return record;
+    }
+
+    public static KnowledgeBaseItem ToModel(this KnowledgeBaseItemEntity entity)
+        => new()
+        {
+            Id = entity.Id,
+            Title = entity.Title,
+            Body = entity.Body,
+            Audience = entity.Audience,
+            Tags = entity.Tags.ToList(),
+            UpdatedAt = entity.UpdatedAt
+        };
+
+    public static KnowledgeBaseItemEntity ToEntity(this KnowledgeBaseItem model)
+        => new()
+        {
+            Id = model.Id,
+            Title = model.Title,
+            Body = model.Body,
+            Audience = model.Audience,
+            Tags = model.Tags.ToList(),
+            UpdatedAt = model.UpdatedAt
+        };
+
+    public static Appeal ToModel(this AppealEntity entity)
+        => new()
+        {
+            Id = entity.Id,
+            MessageId = entity.MessageId,
+            Channel = entity.Channel,
+            UserId = entity.UserId,
+            SubmittedAt = entity.SubmittedAt,
+            Reason = entity.Reason,
+            Status = entity.Status,
+            ResolutionNotes = entity.ResolutionNotes,
+            ReviewedBy = entity.ReviewedBy,
+            ReviewedAt = entity.ReviewedAt
+        };
+
+    public static AppealEntity ToEntity(this Appeal model)
+        => new()
+        {
+            Id = model.Id,
+            MessageId = model.MessageId,
+            Channel = model.Channel,
+            UserId = model.UserId,
+            SubmittedAt = model.SubmittedAt,
+            Reason = model.Reason,
+            Status = model.Status,
+            ResolutionNotes = model.ResolutionNotes,
+            ReviewedBy = model.ReviewedBy,
+            ReviewedAt = model.ReviewedAt
+        };
+}

--- a/backend/NabTeams.Api/Hubs/ChatHub.cs
+++ b/backend/NabTeams.Api/Hubs/ChatHub.cs
@@ -1,0 +1,73 @@
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NabTeams.Api.Configuration;
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Hubs;
+
+public interface IChatClient
+{
+    Task MessageUpserted(Message message);
+}
+
+[Authorize]
+public class ChatHub : Hub<IChatClient>
+{
+    public override async Task OnConnectedAsync()
+    {
+        var httpContext = Context.GetHttpContext();
+        var requestedRole = httpContext?.Request.Query["role"].ToString();
+
+        if (!RoleChannelExtensions.TryParse(requestedRole, out var channel) || !HasChannelAccess(channel))
+        {
+            Context.Abort();
+            return;
+        }
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, BuildGroupName(channel));
+        await base.OnConnectedAsync();
+    }
+
+    internal static string BuildGroupName(RoleChannel channel)
+        => $"chat-{channel.ToString().ToLowerInvariant()}";
+
+    private bool HasChannelAccess(RoleChannel channel)
+    {
+        if (IsAdmin())
+        {
+            return true;
+        }
+
+        var normalized = channel.ToString().ToLowerInvariant();
+        var roles = Context.User?.Claims
+            .Where(c => c.Type == ClaimTypes.Role || c.Type.Equals("role", StringComparison.OrdinalIgnoreCase) || c.Type.Equals("roles", StringComparison.OrdinalIgnoreCase))
+            .Select(c => c.Value.ToLowerInvariant())
+            .ToHashSet();
+
+        return roles is not null && roles.Contains(normalized);
+    }
+
+    private bool IsAdmin()
+    {
+        var adminRole = Context.GetHttpContext()?.RequestServices.GetService<IOptions<AuthenticationSettings>>()?.Value.AdminRole ?? "admin";
+        if (string.IsNullOrWhiteSpace(adminRole))
+        {
+            return false;
+        }
+
+        if (Context.User?.IsInRole(adminRole) == true)
+        {
+            return true;
+        }
+
+        var normalizedAdmin = adminRole.ToLowerInvariant();
+        return Context.User?.Claims
+            .Where(c => c.Type == ClaimTypes.Role || c.Type.Equals("role", StringComparison.OrdinalIgnoreCase) || c.Type.Equals("roles", StringComparison.OrdinalIgnoreCase))
+            .Select(c => c.Value.ToLowerInvariant())
+            .Contains(normalizedAdmin) == true;
+    }
+}

--- a/backend/NabTeams.Api/Models/AppealModels.cs
+++ b/backend/NabTeams.Api/Models/AppealModels.cs
@@ -1,0 +1,22 @@
+namespace NabTeams.Api.Models;
+
+public enum AppealStatus
+{
+    Pending,
+    Accepted,
+    Rejected
+}
+
+public record Appeal
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public Guid MessageId { get; init; }
+    public RoleChannel Channel { get; init; }
+    public string UserId { get; init; } = string.Empty;
+    public DateTimeOffset SubmittedAt { get; init; } = DateTimeOffset.UtcNow;
+    public string Reason { get; init; } = string.Empty;
+    public AppealStatus Status { get; init; } = AppealStatus.Pending;
+    public string? ResolutionNotes { get; init; }
+    public string? ReviewedBy { get; init; }
+    public DateTimeOffset? ReviewedAt { get; init; }
+}

--- a/backend/NabTeams.Api/Models/Message.cs
+++ b/backend/NabTeams.Api/Models/Message.cs
@@ -1,0 +1,51 @@
+namespace NabTeams.Api.Models;
+
+public enum MessageStatus
+{
+    Published,
+    Held,
+    Blocked
+}
+
+public record Message
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public RoleChannel Channel { get; init; }
+    public string SenderUserId { get; init; } = string.Empty;
+    public string Content { get; init; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+    public MessageStatus Status { get; init; }
+    public double ModerationRisk { get; init; }
+    public IReadOnlyCollection<string> ModerationTags { get; init; } = Array.Empty<string>();
+    public string? ModerationNotes { get; init; }
+    public int PenaltyPoints { get; init; }
+};
+
+public record ModerationLog
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public Guid MessageId { get; init; }
+    public string UserId { get; init; } = string.Empty;
+    public RoleChannel Channel { get; init; }
+    public double RiskScore { get; init; }
+    public IReadOnlyCollection<string> PolicyTags { get; init; } = Array.Empty<string>();
+    public string ActionTaken { get; init; } = string.Empty;
+    public int PenaltyPoints { get; init; }
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+};
+
+public record UserDiscipline
+{
+    public string UserId { get; init; } = string.Empty;
+    public RoleChannel Channel { get; init; }
+    public int ScoreBalance { get; set; }
+    public List<DisciplineEvent> History { get; } = new();
+}
+
+public record DisciplineEvent
+{
+    public DateTimeOffset OccurredAt { get; init; } = DateTimeOffset.UtcNow;
+    public string Reason { get; init; } = string.Empty;
+    public int Delta { get; init; }
+    public Guid MessageId { get; init; }
+}

--- a/backend/NabTeams.Api/Models/Requests.cs
+++ b/backend/NabTeams.Api/Models/Requests.cs
@@ -1,0 +1,44 @@
+namespace NabTeams.Api.Models;
+
+public record SendMessageRequest
+{
+    public string Content { get; init; } = string.Empty;
+}
+
+public record SendMessageResponse
+{
+    public Guid MessageId { get; init; }
+    public MessageStatus Status { get; init; }
+    public double ModerationRisk { get; init; }
+    public IReadOnlyCollection<string> ModerationTags { get; init; } = Array.Empty<string>();
+    public string? ModerationNotes { get; init; }
+    public int PenaltyPoints { get; init; }
+    public bool SoftWarn { get; init; }
+    public string? RateLimitMessage { get; init; }
+}
+
+public record MessagesResponse
+{
+    public IReadOnlyCollection<Message> Messages { get; init; } = Array.Empty<Message>();
+}
+
+public record KnowledgeBaseUpsertRequest
+{
+    public string? Id { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Body { get; init; } = string.Empty;
+    public string Audience { get; init; } = string.Empty;
+    public IReadOnlyCollection<string>? Tags { get; init; }
+}
+
+public record CreateAppealRequest
+{
+    public Guid MessageId { get; init; }
+    public string Reason { get; init; } = string.Empty;
+}
+
+public record AppealDecisionRequest
+{
+    public AppealStatus Status { get; init; }
+    public string? Notes { get; init; }
+}

--- a/backend/NabTeams.Api/Models/RoleChannel.cs
+++ b/backend/NabTeams.Api/Models/RoleChannel.cs
@@ -1,0 +1,27 @@
+namespace NabTeams.Api.Models;
+
+public enum RoleChannel
+{
+    Participant,
+    Judge,
+    Mentor,
+    Investor,
+    Admin
+}
+
+public static class RoleChannelExtensions
+{
+    public static bool TryParse(string value, out RoleChannel channel)
+    {
+        if (Enum.TryParse<RoleChannel>(value, true, out var parsed))
+        {
+            channel = parsed;
+            return true;
+        }
+
+        channel = default;
+        return false;
+    }
+
+    public static string ToRouteSegment(this RoleChannel channel) => channel.ToString().ToLowerInvariant();
+}

--- a/backend/NabTeams.Api/Models/SupportModels.cs
+++ b/backend/NabTeams.Api/Models/SupportModels.cs
@@ -1,0 +1,25 @@
+namespace NabTeams.Api.Models;
+
+public record SupportQuery
+{
+    public string Question { get; init; } = string.Empty;
+    public string Role { get; init; } = string.Empty;
+}
+
+public record SupportAnswer
+{
+    public string Answer { get; init; } = string.Empty;
+    public IReadOnlyCollection<string> Sources { get; init; } = Array.Empty<string>();
+    public double Confidence { get; init; }
+    public bool EscalateToHuman { get; init; }
+}
+
+public record KnowledgeBaseItem
+{
+    public string Id { get; init; } = Guid.NewGuid().ToString();
+    public string Title { get; init; } = string.Empty;
+    public string Body { get; init; } = string.Empty;
+    public string Audience { get; init; } = "all";
+    public IReadOnlyCollection<string> Tags { get; init; } = Array.Empty<string>();
+    public DateTimeOffset UpdatedAt { get; init; } = DateTimeOffset.UtcNow;
+}

--- a/backend/NabTeams.Api/NabTeams.Api.csproj
+++ b/backend/NabTeams.Api/NabTeams.Api.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/backend/NabTeams.Api/Program.cs
+++ b/backend/NabTeams.Api/Program.cs
@@ -1,0 +1,139 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using NabTeams.Api.Configuration;
+using NabTeams.Api.Data;
+using NabTeams.Api.Services;
+using NabTeams.Api.Stores;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.Configure<GeminiOptions>(builder.Configuration.GetSection("Gemini"));
+builder.Services.Configure<AuthenticationSettings>(builder.Configuration.GetSection("Authentication"));
+var authenticationSettings = builder.Configuration.GetSection("Authentication").Get<AuthenticationSettings>() ?? new AuthenticationSettings { Disabled = true };
+
+builder.Services.AddHttpClient("gemini", client =>
+{
+    var options = builder.Configuration.GetSection("Gemini").Get<GeminiOptions>() ?? new GeminiOptions();
+    client.BaseAddress = new Uri(options.Endpoint.TrimEnd('/') + "/");
+    client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+});
+
+if (!authenticationSettings.Disabled)
+{
+    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        .AddJwtBearer(options =>
+        {
+            options.Authority = authenticationSettings.Authority;
+            options.Audience = string.IsNullOrWhiteSpace(authenticationSettings.Audience) ? null : authenticationSettings.Audience;
+            options.RequireHttpsMetadata = authenticationSettings.RequireHttpsMetadata;
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                NameClaimType = authenticationSettings.NameClaimType ?? ClaimTypes.NameIdentifier,
+                RoleClaimType = authenticationSettings.RoleClaimType ?? ClaimTypes.Role,
+                ValidateAudience = !string.IsNullOrWhiteSpace(authenticationSettings.Audience)
+            };
+        });
+
+    builder.Services.AddAuthorization(options =>
+    {
+        options.AddPolicy(AuthorizationPolicies.Admin, policy => policy.RequireRole(authenticationSettings.AdminRole));
+    });
+}
+else
+{
+    builder.Services.AddAuthorization(options =>
+    {
+        options.AddPolicy(AuthorizationPolicies.Admin, policy => policy.RequireAssertion(_ => true));
+    });
+}
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? "Host=localhost;Port=5432;Database=nabteams;Username=nabteams;Password=nabteams";
+
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseNpgsql(connectionString));
+
+builder.Services.AddScoped<IChatRepository, EfChatRepository>();
+builder.Services.AddScoped<IModerationLogStore, EfModerationLogStore>();
+builder.Services.AddScoped<IUserDisciplineStore, EfUserDisciplineStore>();
+builder.Services.AddScoped<IAppealStore, EfAppealStore>();
+builder.Services.AddSingleton<IRateLimiter, SlidingWindowRateLimiter>();
+builder.Services.AddSingleton<IModerationService, GeminiModerationService>();
+builder.Services.AddScoped<ISupportKnowledgeBase, EfSupportKnowledgeBase>();
+builder.Services.AddScoped<ISupportResponder, SupportResponder>();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("frontend", policy =>
+        policy.WithOrigins("http://localhost:3000")
+              .AllowAnyHeader()
+              .AllowAnyMethod()
+              .AllowCredentials());
+});
+
+var app = builder.Build();
+
+await DatabaseInitializer.InitializeAsync(app.Services);
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseCors("frontend");
+
+if (!authenticationSettings.Disabled)
+{
+    app.UseAuthentication();
+}
+else
+{
+    app.Use(async (context, next) =>
+    {
+        if (context.User?.Identity?.IsAuthenticated != true)
+        {
+            var debugUser = context.Request.Headers["X-Debug-User"].FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(debugUser))
+            {
+                var identity = new ClaimsIdentity("Debug");
+                identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, debugUser));
+                identity.AddClaim(new Claim("sub", debugUser));
+                identity.AddClaim(new Claim(ClaimTypes.Name, debugUser));
+
+                var debugEmail = context.Request.Headers["X-Debug-Email"].FirstOrDefault();
+                if (!string.IsNullOrWhiteSpace(debugEmail))
+                {
+                    identity.AddClaim(new Claim(ClaimTypes.Email, debugEmail));
+                }
+
+                var rolesHeader = context.Request.Headers["X-Debug-Roles"].FirstOrDefault();
+                if (!string.IsNullOrWhiteSpace(rolesHeader))
+                {
+                    var roles = rolesHeader.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    foreach (var role in roles)
+                    {
+                        identity.AddClaim(new Claim(ClaimTypes.Role, role));
+                        identity.AddClaim(new Claim("role", role));
+                        identity.AddClaim(new Claim("roles", role));
+                    }
+                }
+
+                context.User = new ClaimsPrincipal(identity);
+            }
+        }
+
+        await next();
+    });
+}
+
+app.UseAuthorization();
+app.MapControllers();
+
+app.Run();

--- a/backend/NabTeams.Api/Services/ChatModerationQueue.cs
+++ b/backend/NabTeams.Api/Services/ChatModerationQueue.cs
@@ -1,0 +1,35 @@
+using System.Threading.Channels;
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Services;
+
+public record ChatModerationWorkItem(Guid MessageId, string UserId, RoleChannel Channel, string Content);
+
+public interface IChatModerationQueue
+{
+    ValueTask EnqueueAsync(ChatModerationWorkItem workItem, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<ChatModerationWorkItem> DequeueAsync(CancellationToken cancellationToken);
+}
+
+public class ChatModerationQueue : IChatModerationQueue
+{
+    private readonly Channel<ChatModerationWorkItem> _channel;
+
+    public ChatModerationQueue()
+    {
+        var options = new BoundedChannelOptions(500)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = false,
+            SingleWriter = false
+        };
+
+        _channel = Channel.CreateBounded<ChatModerationWorkItem>(options);
+    }
+
+    public ValueTask EnqueueAsync(ChatModerationWorkItem workItem, CancellationToken cancellationToken = default)
+        => _channel.Writer.WriteAsync(workItem, cancellationToken);
+
+    public IAsyncEnumerable<ChatModerationWorkItem> DequeueAsync(CancellationToken cancellationToken)
+        => _channel.Reader.ReadAllAsync(cancellationToken);
+}

--- a/backend/NabTeams.Api/Services/ChatModerationWorker.cs
+++ b/backend/NabTeams.Api/Services/ChatModerationWorker.cs
@@ -1,0 +1,115 @@
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NabTeams.Api.Hubs;
+using NabTeams.Api.Models;
+using NabTeams.Api.Stores;
+
+namespace NabTeams.Api.Services;
+
+public class ChatModerationWorker : BackgroundService
+{
+    private readonly IChatModerationQueue _queue;
+    private readonly IModerationService _moderationService;
+    private readonly IChatRepository _chatRepository;
+    private readonly IModerationLogStore _moderationLogStore;
+    private readonly IUserDisciplineStore _userDisciplineStore;
+    private readonly IHubContext<ChatHub, IChatClient> _hubContext;
+    private readonly ILogger<ChatModerationWorker> _logger;
+
+    public ChatModerationWorker(
+        IChatModerationQueue queue,
+        IModerationService moderationService,
+        IChatRepository chatRepository,
+        IModerationLogStore moderationLogStore,
+        IUserDisciplineStore userDisciplineStore,
+        IHubContext<ChatHub, IChatClient> hubContext,
+        ILogger<ChatModerationWorker> logger)
+    {
+        _queue = queue;
+        _moderationService = moderationService;
+        _chatRepository = chatRepository;
+        _moderationLogStore = moderationLogStore;
+        _userDisciplineStore = userDisciplineStore;
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var workItem in _queue.DequeueAsync(stoppingToken))
+        {
+            try
+            {
+                await ProcessAsync(workItem, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to process moderation work item for message {MessageId}", workItem.MessageId);
+            }
+        }
+    }
+
+    private async Task ProcessAsync(ChatModerationWorkItem workItem, CancellationToken cancellationToken)
+    {
+        var candidate = new MessageCandidate(workItem.UserId, workItem.Channel, workItem.Content);
+        var moderation = await _moderationService.ModerateAsync(candidate, cancellationToken);
+
+        var status = moderation.Decision switch
+        {
+            ModerationDecision.Publish or ModerationDecision.SoftWarn => MessageStatus.Published,
+            ModerationDecision.Hold => MessageStatus.Held,
+            _ => MessageStatus.Blocked
+        };
+
+        await _chatRepository.UpdateMessageModerationAsync(
+            workItem.MessageId,
+            status,
+            moderation.RiskScore,
+            moderation.PolicyTags,
+            moderation.Notes,
+            moderation.PenaltyPoints,
+            cancellationToken);
+
+        var message = await _chatRepository.GetMessageAsync(workItem.MessageId, cancellationToken);
+        if (message is null)
+        {
+            _logger.LogWarning("Message {MessageId} disappeared before broadcasting moderation result", workItem.MessageId);
+            return;
+        }
+
+        var log = new ModerationLog
+        {
+            MessageId = workItem.MessageId,
+            UserId = workItem.UserId,
+            Channel = workItem.Channel,
+            RiskScore = moderation.RiskScore,
+            PolicyTags = moderation.PolicyTags,
+            ActionTaken = moderation.Decision.ToString(),
+            PenaltyPoints = moderation.PenaltyPoints
+        };
+        await _moderationLogStore.AddAsync(log, cancellationToken);
+
+        if (moderation.PenaltyPoints != 0)
+        {
+            await _userDisciplineStore.UpdateScoreAsync(
+                workItem.UserId,
+                workItem.Channel,
+                -moderation.PenaltyPoints,
+                moderation.Notes,
+                workItem.MessageId,
+                cancellationToken);
+        }
+
+        await _hubContext.Clients.User(workItem.UserId).MessageUpserted(message);
+
+        if (status == MessageStatus.Published)
+        {
+            await _hubContext.Clients.Group(ChatHub.BuildGroupName(workItem.Channel)).MessageUpserted(message);
+        }
+    }
+}

--- a/backend/NabTeams.Api/Services/GeminiModerationService.cs
+++ b/backend/NabTeams.Api/Services/GeminiModerationService.cs
@@ -1,0 +1,276 @@
+using System.Collections.Concurrent;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Options;
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Services;
+
+public class GeminiModerationService : IModerationService
+{
+    private static readonly IReadOnlyList<PolicyRule> Rules = new List<PolicyRule>
+    {
+        new("hate", "نفرت‌پراکنی", 0.75, 6),
+        new("violence", "خشونت", 0.7, 5),
+        new("spam", "اسپم", 0.55, 3),
+        new("cheat", "تقلب", 0.65, 4),
+        new("leak", "افشای اطلاعات", 0.8, 6),
+        new("http://", "لینک", 0.4, 1),
+        new("https://", "لینک", 0.4, 1),
+        new("کدملی", "اطلاعات حساس", 0.85, 8),
+        new("self harm", "خودآسیب", 0.9, 10)
+    };
+
+    private static readonly Regex ProfanityRegex = new("(?i)(لعنتی|احمق|stupid|idiot)", RegexOptions.Compiled);
+    private static readonly ConcurrentDictionary<string, double> TrustAdjustments = new();
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptionsMonitor<GeminiOptions> _options;
+    private readonly ILogger<GeminiModerationService> _logger;
+
+    public GeminiModerationService(
+        IHttpClientFactory httpClientFactory,
+        IOptionsMonitor<GeminiOptions> options,
+        ILogger<GeminiModerationService> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<ModerationResult> ModerateAsync(MessageCandidate candidate, CancellationToken cancellationToken = default)
+    {
+        var options = _options.CurrentValue;
+        if (options.Enabled)
+        {
+            try
+            {
+                var client = _httpClientFactory.CreateClient("gemini");
+                var prompt = BuildModerationPrompt(candidate);
+                var request = new GeminiGenerateRequest(options.ModerationModel, options.ApiKey, prompt);
+                var httpRequest = request.ToHttpRequest();
+
+                var response = await client.SendAsync(httpRequest, cancellationToken);
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+                response.EnsureSuccessStatusCode();
+
+                if (TryParseModeration(body, out var result))
+                {
+                    UpdateTrust(candidate.UserId, result.Decision);
+                    var notes = string.IsNullOrWhiteSpace(result.Notes)
+                        ? "نتیجه بررسی توسط Gemini."
+                        : result.Notes;
+                    return new ModerationResult(result.RiskScore, result.PolicyTags, result.Decision, notes, result.PenaltyPoints);
+                }
+
+                _logger.LogWarning("Gemini moderation response was not parsable: {Body}", body);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Gemini moderation failed, reverting to rule-based fallback");
+            }
+        }
+
+        return RuleBasedModeration(candidate);
+    }
+
+    private static ModerationResult RuleBasedModeration(MessageCandidate candidate)
+    {
+        var lowered = candidate.Content.ToLowerInvariant();
+        var matchedTags = new HashSet<string>();
+        double risk = 0.05;
+        int penalty = 0;
+
+        foreach (var rule in Rules)
+        {
+            if (!lowered.Contains(rule.Keyword))
+            {
+                continue;
+            }
+
+            matchedTags.Add(rule.PolicyTag);
+            risk = Math.Max(risk, rule.RiskScore);
+            penalty = Math.Max(penalty, rule.PenaltyPoints);
+        }
+
+        if (ProfanityRegex.IsMatch(candidate.Content))
+        {
+            matchedTags.Add("توهین");
+            risk = Math.Max(risk, 0.6);
+            penalty = Math.Max(penalty, 4);
+        }
+
+        if (candidate.Content.Length > 600)
+        {
+            matchedTags.Add("پیام طولانی");
+            risk = Math.Max(risk, 0.3);
+        }
+
+        var trustAdjustment = TrustAdjustments.GetOrAdd(candidate.UserId, _ => 0);
+        risk = Math.Clamp(risk + trustAdjustment, 0, 1);
+
+        var decision = DetermineDecision(risk);
+        var notes = decision switch
+        {
+            ModerationDecision.Publish => "پیام سالم شناسایی شد.",
+            ModerationDecision.SoftWarn => "پیام منتشر شد اما شامل علائم ریسک است.",
+            ModerationDecision.Hold => "پیام برای بررسی انسانی نگه داشته شد.",
+            ModerationDecision.Block => "پیام مسدود شد و به کاربر هشدار داده می‌شود.",
+            ModerationDecision.BlockAndReport => "پیام مسدود و برای پیگیری ادمین پرچم شد.",
+            _ => ""
+        };
+
+        UpdateTrust(candidate.UserId, decision);
+        penalty = AdjustPenalty(penalty, decision);
+
+        return new ModerationResult(Math.Round(risk, 2), matchedTags.ToList(), decision, notes, penalty);
+    }
+
+    private static GeminiPrompt BuildModerationPrompt(MessageCandidate candidate)
+    {
+        var instruction = new StringBuilder();
+        instruction.AppendLine("You are an Iranian Farsi-speaking content safety reviewer.");
+        instruction.AppendLine("Analyse the provided message according to the hackathon policy.");
+        instruction.AppendLine("Return JSON with fields: riskScore (0-1), decision (Publish|SoftWarn|Hold|Block|BlockAndReport), policyTags (array of Farsi labels), notes (short Farsi explanation), penaltyPoints (integer).");
+        instruction.AppendLine("Penalty guidance: Publish=0, SoftWarn=1, Hold=2-3, Block=3-5, BlockAndReport=5-10.");
+
+        var userContent = $"پیام کاربر:\n{candidate.Content}\nنقش: {candidate.Channel}";
+        return new GeminiPrompt(instruction.ToString(), userContent);
+    }
+
+    private static bool TryParseModeration(string body, out ModerationResult result)
+    {
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<GeminiResponse>(body, GeminiJson.Options);
+            var text = parsed?.Candidates?.FirstOrDefault()?.Content?.Parts?.FirstOrDefault()?.Text;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                result = default!;
+                return false;
+            }
+
+            var moderation = JsonSerializer.Deserialize<GeminiModerationPayload>(text, GeminiJson.Options);
+            if (moderation is null)
+            {
+                result = default!;
+                return false;
+            }
+
+            if (!Enum.TryParse<ModerationDecision>(moderation.Decision, true, out var decision))
+            {
+                decision = DetermineDecision(moderation.RiskScore);
+            }
+
+            result = new ModerationResult(
+                Math.Clamp(moderation.RiskScore, 0, 1),
+                moderation.PolicyTags ?? Array.Empty<string>(),
+                decision,
+                string.IsNullOrWhiteSpace(moderation.Notes) ? "بررسی با موفقیت انجام شد." : moderation.Notes!,
+                AdjustPenalty(moderation.PenaltyPoints, decision));
+
+            return true;
+        }
+        catch
+        {
+            result = default!;
+            return false;
+        }
+    }
+
+    private static ModerationDecision DetermineDecision(double risk)
+        => risk switch
+        {
+            <= 0.2 => ModerationDecision.Publish,
+            <= 0.4 => ModerationDecision.SoftWarn,
+            <= 0.6 => ModerationDecision.Hold,
+            <= 0.8 => ModerationDecision.Block,
+            _ => ModerationDecision.BlockAndReport
+        };
+
+    private static void UpdateTrust(string userId, ModerationDecision decision)
+    {
+        if (decision is ModerationDecision.Publish or ModerationDecision.SoftWarn)
+        {
+            TrustAdjustments.AddOrUpdate(userId, _ => -0.05, (_, current) => Math.Max(-0.1, current - 0.05));
+        }
+        else
+        {
+            TrustAdjustments.AddOrUpdate(userId, _ => 0.1, (_, current) => Math.Min(0.2, current + 0.05));
+        }
+    }
+
+    private static int AdjustPenalty(int penalty, ModerationDecision decision)
+        => decision switch
+        {
+            ModerationDecision.Publish => 0,
+            ModerationDecision.SoftWarn => Math.Max(penalty, 0),
+            ModerationDecision.Hold => Math.Max(penalty, 1),
+            ModerationDecision.Block => Math.Max(penalty, 3),
+            ModerationDecision.BlockAndReport => Math.Max(penalty, 5),
+            _ => penalty
+        };
+
+    private sealed record PolicyRule(string Keyword, string PolicyTag, double RiskScore, int PenaltyPoints);
+
+    private sealed record GeminiGenerateRequest(string Model, string ApiKey, GeminiPrompt Prompt)
+    {
+        public HttpRequestMessage ToHttpRequest()
+        {
+            var payload = new
+            {
+                systemInstruction = new
+                {
+                    role = "system",
+                    parts = new[] { new { text = Prompt.SystemInstruction } }
+                },
+                contents = new[]
+                {
+                    new
+                    {
+                        role = "user",
+                        parts = new[] { new { text = Prompt.UserContent } }
+                    }
+                },
+                generationConfig = new
+                {
+                    responseMimeType = "application/json",
+                    temperature = 0
+                }
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"models/{Model}:generateContent?key={ApiKey}")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(payload, GeminiJson.Options), Encoding.UTF8, "application/json")
+            };
+            return request;
+        }
+    }
+
+    private sealed record GeminiPrompt(string SystemInstruction, string UserContent);
+
+    private sealed record GeminiResponse(IReadOnlyList<GeminiCandidate>? Candidates);
+    private sealed record GeminiCandidate(GeminiContent? Content);
+    private sealed record GeminiContent(IReadOnlyList<GeminiPart>? Parts);
+    private sealed record GeminiPart(string? Text);
+
+    private sealed record GeminiModerationPayload
+    {
+        public double RiskScore { get; init; }
+        public string Decision { get; init; } = string.Empty;
+        public string[]? PolicyTags { get; init; }
+        public string? Notes { get; init; }
+        public int PenaltyPoints { get; init; }
+    }
+
+    private static class GeminiJson
+    {
+        public static readonly JsonSerializerOptions Options = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+    }
+}

--- a/backend/NabTeams.Api/Services/GeminiOptions.cs
+++ b/backend/NabTeams.Api/Services/GeminiOptions.cs
@@ -1,0 +1,10 @@
+namespace NabTeams.Api.Services;
+
+public class GeminiOptions
+{
+    public string ApiKey { get; set; } = string.Empty;
+    public string Endpoint { get; set; } = "https://generativelanguage.googleapis.com/v1beta";
+    public string ModerationModel { get; set; } = "gemini-1.5-pro";
+    public string RagModel { get; set; } = "gemini-1.5-pro";
+    public bool Enabled => !string.IsNullOrWhiteSpace(ApiKey);
+}

--- a/backend/NabTeams.Api/Services/IModerationService.cs
+++ b/backend/NabTeams.Api/Services/IModerationService.cs
@@ -1,0 +1,26 @@
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Services;
+
+public record ModerationResult(
+    double RiskScore,
+    IReadOnlyCollection<string> PolicyTags,
+    ModerationDecision Decision,
+    string Notes,
+    int PenaltyPoints);
+
+public enum ModerationDecision
+{
+    Publish,
+    SoftWarn,
+    Hold,
+    Block,
+    BlockAndReport
+}
+
+public record MessageCandidate(string UserId, RoleChannel Channel, string Content);
+
+public interface IModerationService
+{
+    Task<ModerationResult> ModerateAsync(MessageCandidate candidate, CancellationToken cancellationToken = default);
+}

--- a/backend/NabTeams.Api/Services/IRateLimiter.cs
+++ b/backend/NabTeams.Api/Services/IRateLimiter.cs
@@ -1,0 +1,10 @@
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Services;
+
+public record RateLimitResult(bool Allowed, TimeSpan? RetryAfter, string? Message);
+
+public interface IRateLimiter
+{
+    RateLimitResult CheckQuota(string userId, RoleChannel channel);
+}

--- a/backend/NabTeams.Api/Services/SlidingWindowRateLimiter.cs
+++ b/backend/NabTeams.Api/Services/SlidingWindowRateLimiter.cs
@@ -1,0 +1,41 @@
+using System.Collections.Concurrent;
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Services;
+
+public class SlidingWindowRateLimiter : IRateLimiter
+{
+    private record RateLimitConfig(int MaxMessages, TimeSpan Window);
+
+    private readonly ConcurrentDictionary<(string UserId, RoleChannel Channel), Queue<DateTimeOffset>> _entries = new();
+    private readonly IReadOnlyDictionary<RoleChannel, RateLimitConfig> _configs = new Dictionary<RoleChannel, RateLimitConfig>
+    {
+        { RoleChannel.Participant, new RateLimitConfig(20, TimeSpan.FromMinutes(5)) },
+        { RoleChannel.Judge, new RateLimitConfig(30, TimeSpan.FromMinutes(5)) },
+        { RoleChannel.Mentor, new RateLimitConfig(25, TimeSpan.FromMinutes(5)) },
+        { RoleChannel.Investor, new RateLimitConfig(15, TimeSpan.FromMinutes(5)) },
+        { RoleChannel.Admin, new RateLimitConfig(40, TimeSpan.FromMinutes(5)) }
+    };
+
+    public RateLimitResult CheckQuota(string userId, RoleChannel channel)
+    {
+        var config = _configs[channel];
+        var now = DateTimeOffset.UtcNow;
+        var key = (userId, channel);
+        var queue = _entries.GetOrAdd(key, _ => new Queue<DateTimeOffset>());
+
+        while (queue.Count > 0 && now - queue.Peek() > config.Window)
+        {
+            queue.Dequeue();
+        }
+
+        if (queue.Count >= config.MaxMessages)
+        {
+            var retryAfter = config.Window - (now - queue.Peek());
+            return new RateLimitResult(false, retryAfter, $"نرخ ارسال پیام شما محدود شده است. لطفاً {retryAfter.TotalSeconds:N0} ثانیه صبر کنید.");
+        }
+
+        queue.Enqueue(now);
+        return new RateLimitResult(true, null, null);
+    }
+}

--- a/backend/NabTeams.Api/Services/SupportResponder.cs
+++ b/backend/NabTeams.Api/Services/SupportResponder.cs
@@ -1,0 +1,250 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Options;
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Services;
+
+public interface ISupportKnowledgeBase
+{
+    Task<IReadOnlyCollection<KnowledgeBaseItem>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<KnowledgeBaseItem> UpsertAsync(KnowledgeBaseItem item, CancellationToken cancellationToken = default);
+    Task DeleteAsync(string id, CancellationToken cancellationToken = default);
+}
+
+public interface ISupportResponder
+{
+    Task<SupportAnswer> GetAnswerAsync(SupportQuery query, CancellationToken cancellationToken = default);
+}
+
+public class SupportResponder : ISupportResponder
+{
+    private readonly ISupportKnowledgeBase _knowledgeBase;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptionsMonitor<GeminiOptions> _options;
+    private readonly ILogger<SupportResponder> _logger;
+
+    public SupportResponder(
+        ISupportKnowledgeBase knowledgeBase,
+        IHttpClientFactory httpClientFactory,
+        IOptionsMonitor<GeminiOptions> options,
+        ILogger<SupportResponder> logger)
+    {
+        _knowledgeBase = knowledgeBase;
+        _httpClientFactory = httpClientFactory;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<SupportAnswer> GetAnswerAsync(SupportQuery query, CancellationToken cancellationToken = default)
+    {
+        var normalizedRole = string.IsNullOrWhiteSpace(query.Role) ? "all" : query.Role.Trim().ToLowerInvariant();
+        var questionTokens = Tokenize(query.Question);
+
+        if (questionTokens.Count == 0)
+        {
+            return new SupportAnswer
+            {
+                Answer = "لطفاً سوال را با جزئیات بیشتری مطرح کنید تا بتوانم کمک کنم.",
+                Confidence = 0,
+                EscalateToHuman = false
+            };
+        }
+
+        var items = await _knowledgeBase.GetAllAsync(cancellationToken);
+        var candidates = items
+            .Where(item => item.Audience.Equals("all", StringComparison.OrdinalIgnoreCase) || item.Audience.Equals(normalizedRole, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (candidates.Count == 0)
+        {
+            return new SupportAnswer
+            {
+                Answer = "هیچ منبعی برای نقش شما ثبت نشده است. لطفاً با ادمین تماس بگیرید.",
+                Confidence = 0,
+                EscalateToHuman = true
+            };
+        }
+
+        var scored = RankCandidates(questionTokens, candidates, normalizedRole);
+        if (scored.Count == 0)
+        {
+            return new SupportAnswer
+            {
+                Answer = "برای این سوال پاسخ دقیقی ندارم. لطفاً سوال را دقیق‌تر بیان کنید یا با تیم پشتیبانی تماس بگیرید.",
+                Confidence = 0.2,
+                EscalateToHuman = true
+            };
+        }
+
+        var options = _options.CurrentValue;
+        if (options.Enabled)
+        {
+            try
+            {
+                return await AskGeminiAsync(query.Question, scored, options, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Gemini RAG request failed; falling back to heuristic response");
+            }
+        }
+
+        return BuildHeuristicAnswer(scored);
+    }
+
+    private static List<(KnowledgeBaseItem Item, double Score)> RankCandidates(IReadOnlyCollection<string> questionTokens, IReadOnlyCollection<KnowledgeBaseItem> candidates, string normalizedRole)
+    {
+        var ranked = new List<(KnowledgeBaseItem Item, double Score)>();
+        foreach (var item in candidates)
+        {
+            var itemTokens = Tokenize(string.Join(' ', item.Tags) + " " + item.Title + " " + item.Body);
+            var overlap = questionTokens.Intersect(itemTokens).Count();
+            var audienceBoost = item.Audience.Equals(normalizedRole, StringComparison.OrdinalIgnoreCase) ? 0.2 : 0;
+            var tagBoost = item.Tags.Intersect(questionTokens, StringComparer.OrdinalIgnoreCase).Count() * 0.1;
+            var score = (overlap / Math.Max(questionTokens.Count, 1)) + audienceBoost + tagBoost;
+            if (score > 0)
+            {
+                ranked.Add((item, Math.Min(score, 1))); // clamp scores to keep ratios meaningful
+            }
+        }
+
+        return ranked
+            .OrderByDescending(x => x.Score)
+            .ThenByDescending(x => x.Item.UpdatedAt)
+            .Take(5)
+            .ToList();
+    }
+
+    private async Task<SupportAnswer> AskGeminiAsync(string question, IReadOnlyCollection<(KnowledgeBaseItem Item, double Score)> scored, GeminiOptions options, CancellationToken cancellationToken)
+    {
+        var contextBuilder = new StringBuilder();
+        foreach (var (item, score) in scored)
+        {
+            contextBuilder.AppendLine($"شناسه: {item.Id}");
+            contextBuilder.AppendLine($"عنوان: {item.Title}");
+            contextBuilder.AppendLine($"متن: {item.Body}");
+            contextBuilder.AppendLine($"نقش: {item.Audience}");
+            contextBuilder.AppendLine($"امتیاز تقریبی: {score:0.00}");
+            contextBuilder.AppendLine("---");
+        }
+
+        var client = _httpClientFactory.CreateClient("gemini");
+        var instruction = new StringBuilder();
+        instruction.AppendLine("You are a knowledgeable Persian support assistant for a hackathon management platform.");
+        instruction.AppendLine("Answer in Persian (fa-IR) using only the provided context snippets.");
+        instruction.AppendLine("Return JSON with fields: answer (string), sources (array of snippet ids), confidence (0-1), escalateToHuman (boolean).");
+        instruction.AppendLine("If information is missing, set escalateToHuman to true and explain what is unclear.");
+
+        var userContent = $"پرسش:\n{question}\n\nمنابع:\n{contextBuilder}";
+        var payload = new
+        {
+            systemInstruction = new
+            {
+                role = "system",
+                parts = new[] { new { text = instruction.ToString() } }
+            },
+            contents = new[]
+            {
+                new
+                {
+                    role = "user",
+                    parts = new[] { new { text = userContent } }
+                }
+            },
+            generationConfig = new
+            {
+                responseMimeType = "application/json",
+                temperature = 0.2
+            }
+        };
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"models/{options.RagModel}:generateContent?key={options.ApiKey}")
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload, GeminiJson.Options), Encoding.UTF8, "application/json")
+        };
+
+        var response = await client.SendAsync(request, cancellationToken);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var parsed = JsonSerializer.Deserialize<GeminiResponse>(body, GeminiJson.Options);
+        var text = parsed?.Candidates?.FirstOrDefault()?.Content?.Parts?.FirstOrDefault()?.Text;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            throw new InvalidOperationException("Gemini پاسخ خالی برگرداند.");
+        }
+
+        var ragPayload = JsonSerializer.Deserialize<GeminiSupportPayload>(text, GeminiJson.Options);
+        if (ragPayload is null)
+        {
+            throw new InvalidOperationException("ساختار پاسخ Gemini قابل پردازش نبود.");
+        }
+
+        return new SupportAnswer
+        {
+            Answer = ragPayload.Answer ?? "پاسخی یافت نشد.",
+            Sources = ragPayload.Sources ?? scored.Select(x => x.Item.Id).ToList(),
+            Confidence = Math.Clamp(ragPayload.Confidence, 0, 1),
+            EscalateToHuman = ragPayload.EscalateToHuman
+        };
+    }
+
+    private static SupportAnswer BuildHeuristicAnswer(IReadOnlyCollection<(KnowledgeBaseItem Item, double Score)> scored)
+    {
+        var primary = scored.First();
+        var supporting = scored.Skip(1).ToList();
+        var builder = new StringBuilder();
+        builder.AppendLine(primary.Item.Title + ":");
+        builder.AppendLine(primary.Item.Body.Trim());
+
+        if (supporting.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("منابع مرتبط دیگر:");
+            foreach (var item in supporting)
+            {
+                builder.AppendLine($"• {item.Item.Title}: {item.Item.Body}");
+            }
+        }
+
+        var confidence = Math.Clamp(primary.Score, 0, 1);
+        return new SupportAnswer
+        {
+            Answer = builder.ToString().Trim(),
+            Sources = scored.Select(x => x.Item.Id).ToList(),
+            Confidence = confidence,
+            EscalateToHuman = confidence < 0.35
+        };
+    }
+
+    private static IReadOnlyCollection<string> Tokenize(string text)
+    {
+        text = text.ToLowerInvariant();
+        text = Regex.Replace(text, "[^\\p{L}\\p{Nd} ]+", " ");
+        return text.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private sealed record GeminiResponse(IReadOnlyList<GeminiCandidate>? Candidates);
+    private sealed record GeminiCandidate(GeminiContent? Content);
+    private sealed record GeminiContent(IReadOnlyList<GeminiPart>? Parts);
+    private sealed record GeminiPart(string? Text);
+
+    private sealed record GeminiSupportPayload
+    {
+        public string? Answer { get; init; }
+        public List<string>? Sources { get; init; }
+        public double Confidence { get; init; }
+        public bool EscalateToHuman { get; init; }
+    }
+
+    private static class GeminiJson
+    {
+        public static readonly JsonSerializerOptions Options = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+    }
+}

--- a/backend/NabTeams.Api/Stores/EfStores.cs
+++ b/backend/NabTeams.Api/Stores/EfStores.cs
@@ -1,0 +1,269 @@
+using Microsoft.EntityFrameworkCore;
+using NabTeams.Api.Data;
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Stores;
+
+public class EfChatRepository : IChatRepository
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public EfChatRepository(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task AddMessageAsync(Message message, CancellationToken cancellationToken = default)
+    {
+        var entity = message.ToEntity();
+        _dbContext.Messages.Add(entity);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyCollection<Message>> GetMessagesAsync(RoleChannel channel, CancellationToken cancellationToken = default)
+    {
+        var items = await _dbContext.Messages
+            .AsNoTracking()
+            .Where(m => m.Channel == channel && m.Status != MessageStatus.Blocked)
+            .OrderBy(m => m.CreatedAt)
+            .Take(500)
+            .ToListAsync(cancellationToken);
+
+        return items.Select(m => m.ToModel()).ToList();
+    }
+
+    public async Task<Message?> GetMessageAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _dbContext.Messages
+            .AsNoTracking()
+            .SingleOrDefaultAsync(m => m.Id == id, cancellationToken);
+
+        return entity?.ToModel();
+    }
+}
+
+public class EfModerationLogStore : IModerationLogStore
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public EfModerationLogStore(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task AddAsync(ModerationLog log, CancellationToken cancellationToken = default)
+    {
+        _dbContext.ModerationLogs.Add(log.ToEntity());
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyCollection<ModerationLog>> QueryAsync(RoleChannel channel, CancellationToken cancellationToken = default)
+    {
+        var logs = await _dbContext.ModerationLogs
+            .AsNoTracking()
+            .Where(l => l.Channel == channel)
+            .OrderByDescending(l => l.CreatedAt)
+            .Take(200)
+            .ToListAsync(cancellationToken);
+
+        return logs.Select(l => l.ToModel()).ToList();
+    }
+
+    public async Task<ModerationLog?> GetAsync(Guid messageId, CancellationToken cancellationToken = default)
+    {
+        var entity = await _dbContext.ModerationLogs
+            .AsNoTracking()
+            .SingleOrDefaultAsync(l => l.MessageId == messageId, cancellationToken);
+
+        return entity?.ToModel();
+    }
+}
+
+public class EfUserDisciplineStore : IUserDisciplineStore
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public EfUserDisciplineStore(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<UserDiscipline> UpdateScoreAsync(string userId, RoleChannel channel, int delta, string reason, Guid messageId, CancellationToken cancellationToken = default)
+    {
+        var record = await _dbContext.UserDisciplines
+            .Include(x => x.Events)
+            .SingleOrDefaultAsync(x => x.UserId == userId && x.Channel == channel, cancellationToken);
+
+        if (record is null)
+        {
+            record = new UserDisciplineEntity
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Channel = channel,
+                ScoreBalance = 0
+            };
+            _dbContext.UserDisciplines.Add(record);
+        }
+
+        record.ScoreBalance += delta;
+        record.Events.Add(new DisciplineEventEntity
+        {
+            Id = Guid.NewGuid(),
+            MessageId = messageId,
+            OccurredAt = DateTimeOffset.UtcNow,
+            Delta = delta,
+            Reason = reason,
+            UserDisciplineId = record.Id
+        });
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return (await GetAsync(userId, channel, cancellationToken))!;
+    }
+
+    public async Task<UserDiscipline?> GetAsync(string userId, RoleChannel channel, CancellationToken cancellationToken = default)
+    {
+        var record = await _dbContext.UserDisciplines
+            .AsNoTracking()
+            .Include(x => x.Events)
+            .SingleOrDefaultAsync(x => x.UserId == userId && x.Channel == channel, cancellationToken);
+
+        return record?.ToModel();
+    }
+}
+
+public class EfSupportKnowledgeBase : ISupportKnowledgeBase
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public EfSupportKnowledgeBase(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyCollection<KnowledgeBaseItem>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var items = await _dbContext.KnowledgeBaseItems
+            .AsNoTracking()
+            .OrderByDescending(i => i.UpdatedAt)
+            .ToListAsync(cancellationToken);
+
+        return items.Select(i => i.ToModel()).ToList();
+    }
+
+    public async Task<KnowledgeBaseItem> UpsertAsync(KnowledgeBaseItem item, CancellationToken cancellationToken = default)
+    {
+        var existing = await _dbContext.KnowledgeBaseItems
+            .SingleOrDefaultAsync(i => i.Id == item.Id, cancellationToken);
+
+        if (existing is null)
+        {
+            existing = item.ToEntity();
+            existing.UpdatedAt = DateTimeOffset.UtcNow;
+            _dbContext.KnowledgeBaseItems.Add(existing);
+        }
+        else
+        {
+            existing.Title = item.Title;
+            existing.Body = item.Body;
+            existing.Audience = item.Audience;
+            existing.Tags = item.Tags.ToList();
+            existing.UpdatedAt = DateTimeOffset.UtcNow;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return existing.ToModel();
+    }
+
+    public async Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+    {
+        var existing = await _dbContext.KnowledgeBaseItems
+            .SingleOrDefaultAsync(i => i.Id == id, cancellationToken);
+
+        if (existing is null)
+        {
+            return;
+        }
+
+        _dbContext.KnowledgeBaseItems.Remove(existing);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}
+
+public class EfAppealStore : IAppealStore
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public EfAppealStore(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<Appeal> CreateAsync(Appeal appeal, CancellationToken cancellationToken = default)
+    {
+        var entity = appeal.ToEntity();
+        _dbContext.Appeals.Add(entity);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return entity.ToModel();
+    }
+
+    public async Task<IReadOnlyCollection<Appeal>> GetForUserAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        var results = await _dbContext.Appeals
+            .AsNoTracking()
+            .Where(a => a.UserId == userId)
+            .OrderByDescending(a => a.SubmittedAt)
+            .ToListAsync(cancellationToken);
+
+        return results.Select(a => a.ToModel()).ToList();
+    }
+
+    public async Task<IReadOnlyCollection<Appeal>> QueryAsync(RoleChannel? channel, AppealStatus? status, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.Appeals.AsNoTracking().AsQueryable();
+
+        if (channel.HasValue)
+        {
+            query = query.Where(a => a.Channel == channel.Value);
+        }
+
+        if (status.HasValue)
+        {
+            query = query.Where(a => a.Status == status.Value);
+        }
+
+        var results = await query
+            .OrderBy(a => a.Status)
+            .ThenByDescending(a => a.SubmittedAt)
+            .Take(200)
+            .ToListAsync(cancellationToken);
+
+        return results.Select(a => a.ToModel()).ToList();
+    }
+
+    public async Task<Appeal?> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _dbContext.Appeals
+            .AsNoTracking()
+            .SingleOrDefaultAsync(a => a.Id == id, cancellationToken);
+
+        return entity?.ToModel();
+    }
+
+    public async Task<Appeal?> ResolveAsync(Guid id, AppealStatus status, string reviewerId, string? notes, CancellationToken cancellationToken = default)
+    {
+        var entity = await _dbContext.Appeals.SingleOrDefaultAsync(a => a.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return null;
+        }
+
+        entity.Status = status;
+        entity.ResolutionNotes = notes;
+        entity.ReviewedBy = reviewerId;
+        entity.ReviewedAt = DateTimeOffset.UtcNow;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return entity.ToModel();
+    }
+}

--- a/backend/NabTeams.Api/Stores/EfStores.cs
+++ b/backend/NabTeams.Api/Stores/EfStores.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using NabTeams.Api.Data;
 using NabTeams.Api.Models;
+using System.Linq;
 
 namespace NabTeams.Api.Stores;
 
@@ -39,6 +40,32 @@ public class EfChatRepository : IChatRepository
             .SingleOrDefaultAsync(m => m.Id == id, cancellationToken);
 
         return entity?.ToModel();
+    }
+
+    public async Task UpdateMessageModerationAsync(
+        Guid messageId,
+        MessageStatus status,
+        double risk,
+        IReadOnlyCollection<string> tags,
+        string? notes,
+        int penaltyPoints,
+        CancellationToken cancellationToken = default)
+    {
+        var entity = await _dbContext.Messages
+            .SingleOrDefaultAsync(m => m.Id == messageId, cancellationToken);
+
+        if (entity is null)
+        {
+            return;
+        }
+
+        entity.Status = status;
+        entity.ModerationRisk = risk;
+        entity.ModerationTags = tags.ToList();
+        entity.ModerationNotes = notes;
+        entity.PenaltyPoints = penaltyPoints;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
     }
 }
 

--- a/backend/NabTeams.Api/Stores/IChatRepository.cs
+++ b/backend/NabTeams.Api/Stores/IChatRepository.cs
@@ -1,0 +1,32 @@
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Stores;
+
+public interface IChatRepository
+{
+    Task AddMessageAsync(Message message, CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<Message>> GetMessagesAsync(RoleChannel channel, CancellationToken cancellationToken = default);
+    Task<Message?> GetMessageAsync(Guid id, CancellationToken cancellationToken = default);
+}
+
+public interface IModerationLogStore
+{
+    Task AddAsync(ModerationLog log, CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<ModerationLog>> QueryAsync(RoleChannel channel, CancellationToken cancellationToken = default);
+    Task<ModerationLog?> GetAsync(Guid messageId, CancellationToken cancellationToken = default);
+}
+
+public interface IUserDisciplineStore
+{
+    Task<UserDiscipline> UpdateScoreAsync(string userId, RoleChannel channel, int delta, string reason, Guid messageId, CancellationToken cancellationToken = default);
+    Task<UserDiscipline?> GetAsync(string userId, RoleChannel channel, CancellationToken cancellationToken = default);
+}
+
+public interface IAppealStore
+{
+    Task<Appeal> CreateAsync(Appeal appeal, CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<Appeal>> GetForUserAsync(string userId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<Appeal>> QueryAsync(RoleChannel? channel, AppealStatus? status, CancellationToken cancellationToken = default);
+    Task<Appeal?> GetAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<Appeal?> ResolveAsync(Guid id, AppealStatus status, string reviewerId, string? notes, CancellationToken cancellationToken = default);
+}

--- a/backend/NabTeams.Api/Stores/IChatRepository.cs
+++ b/backend/NabTeams.Api/Stores/IChatRepository.cs
@@ -7,6 +7,14 @@ public interface IChatRepository
     Task AddMessageAsync(Message message, CancellationToken cancellationToken = default);
     Task<IReadOnlyCollection<Message>> GetMessagesAsync(RoleChannel channel, CancellationToken cancellationToken = default);
     Task<Message?> GetMessageAsync(Guid id, CancellationToken cancellationToken = default);
+    Task UpdateMessageModerationAsync(
+        Guid messageId,
+        MessageStatus status,
+        double risk,
+        IReadOnlyCollection<string> tags,
+        string? notes,
+        int penaltyPoints,
+        CancellationToken cancellationToken = default);
 }
 
 public interface IModerationLogStore

--- a/backend/NabTeams.Api/Stores/InMemoryStores.cs
+++ b/backend/NabTeams.Api/Stores/InMemoryStores.cs
@@ -1,0 +1,88 @@
+using System.Collections.Concurrent;
+using NabTeams.Api.Models;
+
+namespace NabTeams.Api.Stores;
+
+public class InMemoryChatRepository : IChatRepository
+{
+    private readonly ConcurrentDictionary<RoleChannel, List<Message>> _messages = new();
+
+    public Task AddMessageAsync(Message message, CancellationToken cancellationToken = default)
+    {
+        var list = _messages.GetOrAdd(message.Channel, _ => new List<Message>());
+        lock (list)
+        {
+            list.Add(message);
+            if (list.Count > 500)
+            {
+                list.RemoveRange(0, list.Count - 500);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyCollection<Message>> GetMessagesAsync(RoleChannel channel, CancellationToken cancellationToken = default)
+    {
+        var list = _messages.GetOrAdd(channel, _ => new List<Message>());
+        lock (list)
+        {
+            return Task.FromResult((IReadOnlyCollection<Message>)list.OrderBy(m => m.CreatedAt).ToList());
+        }
+    }
+}
+
+public class InMemoryModerationLogStore : IModerationLogStore
+{
+    private readonly ConcurrentBag<ModerationLog> _logs = new();
+
+    public Task AddAsync(ModerationLog log, CancellationToken cancellationToken = default)
+    {
+        _logs.Add(log);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyCollection<ModerationLog>> QueryAsync(RoleChannel channel, CancellationToken cancellationToken = default)
+    {
+        var results = _logs.Where(l => l.Channel == channel)
+            .OrderByDescending(l => l.CreatedAt)
+            .Take(100)
+            .ToList();
+        return Task.FromResult((IReadOnlyCollection<ModerationLog>)results);
+    }
+}
+
+public class InMemoryUserDisciplineStore : IUserDisciplineStore
+{
+    private readonly ConcurrentDictionary<(string UserId, RoleChannel Channel), UserDiscipline> _users = new();
+
+    public Task<UserDiscipline> UpdateScoreAsync(string userId, RoleChannel channel, int delta, string reason, Guid messageId, CancellationToken cancellationToken = default)
+    {
+        var key = (userId, channel);
+        var record = _users.GetOrAdd(key, _ => new UserDiscipline
+        {
+            UserId = userId,
+            Channel = channel
+        });
+
+        lock (record)
+        {
+            record.ScoreBalance += delta;
+            record.History.Add(new DisciplineEvent
+            {
+                Delta = delta,
+                MessageId = messageId,
+                Reason = reason,
+                OccurredAt = DateTimeOffset.UtcNow
+            });
+        }
+
+        return Task.FromResult(record);
+    }
+
+    public Task<UserDiscipline?> GetAsync(string userId, RoleChannel channel, CancellationToken cancellationToken = default)
+    {
+        var key = (userId, channel);
+        return Task.FromResult(_users.TryGetValue(key, out var record) ? record : null);
+    }
+}

--- a/backend/NabTeams.Api/appsettings.json
+++ b/backend/NabTeams.Api/appsettings.json
@@ -1,0 +1,20 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=nabteams;Username=nabteams;Password=nabteams"
+  },
+  "Gemini": {
+    "ApiKey": "",
+    "Endpoint": "https://generativelanguage.googleapis.com/v1beta",
+    "ModerationModel": "gemini-1.5-pro",
+    "RagModel": "gemini-1.5-pro"
+  },
+  "Authentication": {
+    "Disabled": true,
+    "Authority": "https://sso.example.com/realms/nabteams",
+    "Audience": "nabteams-api",
+    "AdminRole": "admin",
+    "RequireHttpsMetadata": true,
+    "NameClaimType": "sub",
+    "RoleClaimType": "role"
+  }
+}

--- a/frontend/app/(dashboard)/global-chat/page.tsx
+++ b/frontend/app/(dashboard)/global-chat/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+import { ChatPanel } from '../../../components/chat-panel';
+
+export default function GlobalChatPage() {
+  return (
+    <div className="space-y-6">
+      <Link href="/" className="text-sm text-slate-400 hover:text-slate-200">
+        ← بازگشت به داشبورد
+      </Link>
+      <ChatPanel />
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/knowledge-base/page.tsx
+++ b/frontend/app/(dashboard)/knowledge-base/page.tsx
@@ -1,0 +1,16 @@
+import { KnowledgeBaseManager } from '../../../components/knowledge-base-manager';
+
+export default function KnowledgeBasePage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">مدیریت دانش ادمین</h1>
+        <p className="text-slate-300 max-w-3xl text-sm leading-6">
+          در این بخش می‌توانید منابع دانش را برای نقش‌های مختلف اضافه یا به‌روزرسانی کنید. تغییرات بلافاصله در چت پشتیبانی قابل
+          استفاده خواهد بود.
+        </p>
+      </header>
+      <KnowledgeBaseManager />
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/support/page.tsx
+++ b/frontend/app/(dashboard)/support/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+import { SupportPanel } from '../../../components/support-panel';
+
+export default function SupportPage() {
+  return (
+    <div className="space-y-6">
+      <Link href="/" className="text-sm text-slate-400 hover:text-slate-200">
+        ← بازگشت به داشبورد
+      </Link>
+      <SupportPanel />
+    </div>
+  );
+}

--- a/frontend/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,86 @@
+import NextAuth from 'next-auth';
+import OAuthProvider from 'next-auth/providers/oauth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+
+const issuer = process.env.SSO_ISSUER;
+const clientId = process.env.SSO_CLIENT_ID;
+const clientSecret = process.env.SSO_CLIENT_SECRET;
+const scope = process.env.SSO_SCOPE ?? 'openid profile email offline_access roles';
+const allowDevCredentials = process.env.AUTH_ALLOW_DEV === 'true';
+
+const providers = [] as any[];
+
+if (issuer && clientId && clientSecret) {
+  providers.push(
+    OAuthProvider({
+      id: 'nabteams-sso',
+      name: 'NabTeams SSO',
+      clientId,
+      clientSecret,
+      issuer,
+      authorization: { params: { scope } }
+    })
+  );
+}
+
+if (providers.length === 0 || allowDevCredentials) {
+  providers.push(
+    CredentialsProvider({
+      id: 'dev-login',
+      name: 'ورود آزمایشی',
+      credentials: {
+        email: { label: 'ایمیل', type: 'email' },
+        role: { label: 'نقش', type: 'text', placeholder: 'participant' }
+      },
+      authorize(credentials) {
+        if (!credentials?.email) {
+          return null;
+        }
+        const role = (credentials.role ?? 'participant').toString().toLowerCase();
+        return {
+          id: credentials.email,
+          name: credentials.email,
+          email: credentials.email,
+          roles: [role]
+        } as any;
+      }
+    })
+  );
+}
+
+if (providers.length === 0) {
+  throw new Error('هیچ ارائه‌دهنده احراز هویتی پیکربندی نشده است. متغیرهای محیطی SSO را تنظیم کنید.');
+}
+
+const handler = NextAuth({
+  providers,
+  session: { strategy: 'jwt' },
+  pages: { signIn: '/auth/signin' },
+  callbacks: {
+    async jwt({ token, account, profile, user }) {
+      if (account) {
+        token.accessToken = (account as any).access_token ?? (account as any).id_token ?? token.accessToken;
+      }
+      if (user && (user as any).roles) {
+        token.roles = (user as any).roles as string[];
+      } else if (profile && (profile as any).roles) {
+        const roles = Array.isArray((profile as any).roles)
+          ? ((profile as any).roles as string[])
+          : [String((profile as any).roles)];
+        token.roles = roles;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      session.accessToken = token.accessToken as string | undefined;
+      session.user = {
+        ...session.user,
+        id: token.sub,
+        roles: (token.roles as string[] | undefined) ?? session.user?.roles ?? []
+      };
+      return session;
+    }
+  }
+});
+
+export { handler as GET, handler as POST };

--- a/frontend/app/appeals/page.tsx
+++ b/frontend/app/appeals/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+import { AppealsPanel } from '../../components/appeals-panel';
+
+export default function AppealsPage() {
+  return (
+    <div className="space-y-6">
+      <Link href="/" className="text-sm text-slate-400 hover:text-slate-200">
+        ← بازگشت به داشبورد
+      </Link>
+      <AppealsPanel />
+    </div>
+  );
+}

--- a/frontend/app/auth/signin/page.tsx
+++ b/frontend/app/auth/signin/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { signIn } from 'next-auth/react';
+
+export default function SignInPage() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 text-center">
+      <h1 className="text-3xl font-semibold text-slate-100">ورود به سامانه NabTeams</h1>
+      <p className="max-w-md text-sm text-slate-400">
+        برای دسترسی به چت گلوبال نقش‌محور و پشتیبانی دانشی، لطفاً از SSO سازمانی استفاده کنید. در محیط‌های آزمایشی می‌توانید از ورود آزمایشی نیز بهره ببرید.
+      </p>
+      <div className="flex flex-col gap-3">
+        <button
+          onClick={() => signIn('nabteams-sso')}
+          className="rounded-lg bg-emerald-500 px-6 py-3 text-sm font-semibold text-emerald-950 shadow-lg shadow-emerald-500/20"
+        >
+          ورود با SSO سازمانی
+        </button>
+        <button
+          onClick={() => signIn('dev-login')}
+          className="rounded-lg border border-slate-600 px-6 py-3 text-sm font-semibold text-slate-200"
+        >
+          ورود آزمایشی
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,17 @@
+:root {
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,27 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { Rubik } from 'next/font/google';
+import { Providers } from './providers';
+
+const rubik = Rubik({ subsets: ['latin', 'arabic'] });
+
+export const metadata: Metadata = {
+  title: 'NabTeams Dashboard',
+  description: 'Role-based collaboration with AI moderation and support'
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="fa" dir="rtl">
+      <body className={`${rubik.className} bg-slate-950 text-slate-100 min-h-screen`}>
+        <Providers>
+          <main className="max-w-6xl mx-auto px-4 py-6">{children}</main>
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import Link from 'next/link';
+import { signIn, signOut, useSession } from 'next-auth/react';
+import { RoleSwitcher } from '../components/role-switcher';
+
+export default function HomePage() {
+  const { data: session, status } = useSession();
+  const isAuthenticated = status === 'authenticated';
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold">داشبورد تعاملی نب‌تیمز</h1>
+            <p className="text-slate-300 max-w-3xl">
+              این نسخه شامل چت گلوبال نقش‌محور با پایش محتوایی Gemini، چت پشتیبانی مبتنی بر دانش ادمین و مدیریت اعتراض‌ها است. برای استفاده، ابتدا از طریق SSO وارد شوید.
+            </p>
+          </div>
+          <div className="flex flex-col items-end gap-2 text-sm text-slate-300">
+            {isAuthenticated ? (
+              <>
+                <span>{session?.user?.email ?? session?.user?.name}</span>
+                <button
+                  onClick={() => signOut()}
+                  className="rounded-lg border border-slate-600 px-3 py-1 text-xs text-slate-200"
+                >
+                  خروج از حساب
+                </button>
+              </>
+            ) : (
+              <button
+                onClick={() => signIn()}
+                className="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-medium text-emerald-950"
+              >
+                ورود با SSO یا ورود آزمایشی
+              </button>
+            )}
+          </div>
+        </div>
+        {isAuthenticated && <RoleSwitcher />}
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <DashboardLink
+          href="/(dashboard)/global-chat"
+          title="👥 چت گلوبال"
+          description="پیام‌های نقش خود را در کانال اختصاصی ارسال کنید و نتیجه‌ی پایش محتوایی را به صورت لحظه‌ای ببینید."
+        />
+        <DashboardLink
+          href="/(dashboard)/support"
+          title="🛟 پشتیبانی دانشی"
+          description="پرسش‌های خود را مطرح کنید تا Gemini بر اساس دانش‌پایه‌ی ادمین پاسخ دهد و در صورت نیاز انتقال به اپراتور انجام شود."
+        />
+        <DashboardLink
+          href="/(dashboard)/knowledge-base"
+          title="📚 مدیریت دانش ادمین"
+          description="منابع پاسخ‌گویی را سازمان‌دهی کنید، مخاطبان هر منبع را تعیین و تاثیر تغییرات را بلافاصله در چت پشتیبانی مشاهده کنید."
+        />
+        <DashboardLink
+          href="/appeals"
+          title="⚖️ اعتراض‌های انضباطی"
+          description="درخواست بازبینی برای پیام‌های مسدودشده ثبت کنید یا وضعیت اعتراض‌های قبلی را دنبال کنید."
+        />
+      </section>
+    </div>
+  );
+}
+
+function DashboardLink({
+  href,
+  title,
+  description
+}: {
+  href: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <Link href={href} className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 transition hover:border-slate-600">
+      <h2 className="text-2xl font-medium mb-2">{title}</h2>
+      <p className="text-sm text-slate-300">{description}</p>
+    </Link>
+  );
+}

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+import { RoleProvider } from '../lib/role-context';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <SessionProvider>
+      <RoleProvider>{children}</RoleProvider>
+    </SessionProvider>
+  );
+}

--- a/frontend/components/appeals-panel.tsx
+++ b/frontend/components/appeals-panel.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import {
+  Appeal,
+  AppealStatus,
+  createAppeal,
+  fetchAppeals,
+  queryAppeals,
+  resolveAppeal,
+  Role
+} from '../lib/api';
+import { useRole } from '../lib/use-role';
+
+export function AppealsPanel() {
+  const { data: session, status } = useSession();
+  const accessToken = session?.accessToken;
+  const isAuthenticated = status === 'authenticated';
+  const currentRole = useRole();
+  const isAdmin = (session?.user?.roles ?? []).includes('admin');
+  const sessionUser = session?.user
+    ? {
+        id: session.user.id ?? session.user.email ?? null,
+        email: session.user.email ?? null,
+        name: session.user.name ?? null,
+        roles: session.user.roles ?? null
+      }
+    : undefined;
+  const auth = useMemo(
+    () => ({ accessToken, sessionUser }),
+    [accessToken, sessionUser?.id, sessionUser?.email, sessionUser?.name, sessionUser?.roles?.join(',')]
+  );
+  const hasAuth = Boolean(accessToken) || Boolean(sessionUser?.id);
+  const [messageId, setMessageId] = useState('');
+  const [reason, setReason] = useState('');
+  const [appeals, setAppeals] = useState<Appeal[]>([]);
+  const [adminAppeals, setAdminAppeals] = useState<Appeal[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [adminFilters, setAdminFilters] = useState<{ role?: Role; status?: AppealStatus }>({ status: 'Pending' });
+
+  useEffect(() => {
+    if (!isAuthenticated || !hasAuth) {
+      setAppeals([]);
+      return;
+    }
+    let cancelled = false;
+    async function load() {
+      try {
+        const data = await fetchAppeals(auth);
+        if (!cancelled) {
+          setAppeals(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError((err as Error).message);
+        }
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [auth, accessToken, hasAuth, isAuthenticated]);
+
+  useEffect(() => {
+    if (!isAdmin || !hasAuth) {
+      setAdminAppeals([]);
+      return;
+    }
+    let cancelled = false;
+    async function loadAdmin() {
+      try {
+        const data = await queryAppeals(auth, adminFilters);
+        if (!cancelled) {
+          setAdminAppeals(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError((err as Error).message);
+        }
+      }
+    }
+    loadAdmin();
+    return () => {
+      cancelled = true;
+    };
+  }, [auth, accessToken, hasAuth, isAdmin, adminFilters]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!isAuthenticated || !hasAuth || !messageId.trim() || !reason.trim()) {
+      setError('شناسه پیام و دلیل اعتراض الزامی است.');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const saved = await createAppeal({ messageId: messageId.trim(), reason: reason.trim() }, auth);
+      setAppeals((prev) => [saved, ...prev]);
+      setSuccess('اعتراض ثبت شد و در انتظار بررسی است.');
+      setMessageId('');
+      setReason('');
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleResolve = async (id: string, status: AppealStatus) => {
+    if (!isAuthenticated || !hasAuth) {
+      return;
+    }
+    try {
+      const resolved = await resolveAppeal(id, { status }, auth);
+      setAdminAppeals((prev) => prev.map((item) => (item.id === id ? resolved : item)));
+      setAppeals((prev) => prev.map((item) => (item.id === id ? resolved : item)));
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-5">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-semibold">ثبت اعتراض جدید</h1>
+          <p className="text-slate-400 text-sm">
+            شناسه پیام را از پاسخ چت یا لاگ انضباطی دریافت کرده و دلیل اعتراض را به طور مختصر بیان کنید. اعتراض برای ادمین ارسال می‌شود.
+          </p>
+        </header>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col gap-2 text-sm">
+              <span className="text-slate-300">شناسه پیام</span>
+              <input
+                value={messageId}
+                onChange={(event) => setMessageId(event.target.value)}
+                className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100"
+                placeholder="00000000-0000-0000-0000-000000000000"
+                disabled={!hasAuth}
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm">
+              <span className="text-slate-300">نقش فعال</span>
+              <input
+                value={currentRole}
+                disabled
+                className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100"
+              />
+            </label>
+          </div>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-slate-300">دلیل اعتراض</span>
+            <textarea
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              rows={4}
+              className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-3 text-sm text-slate-100"
+              disabled={!hasAuth}
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={loading || !hasAuth}
+            className="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-medium text-emerald-950 disabled:opacity-60"
+          >
+            {loading ? 'در حال ارسال...' : 'ثبت اعتراض'}
+          </button>
+          {success && <p className="text-sm text-emerald-300">{success}</p>}
+          {error && <p className="text-sm text-rose-300">{error}</p>}
+        </form>
+        {(!isAuthenticated || !hasAuth) && (
+          <p className="text-sm text-rose-200">برای ثبت اعتراض ابتدا وارد حساب کاربری شوید.</p>
+        )}
+      </section>
+
+      <section className="space-y-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-5">
+        <header className="space-y-1">
+          <h2 className="text-xl font-semibold">اعتراض‌های من</h2>
+          <p className="text-sm text-slate-400">وضعیت اعتراض‌های ثبت‌شده توسط شما در این بخش نمایش داده می‌شود.</p>
+        </header>
+        {appeals.length === 0 ? (
+          <p className="text-sm text-slate-400">اعتراضی ثبت نشده است.</p>
+        ) : (
+          <ul className="space-y-4">
+            {appeals.map((appeal) => (
+              <li key={appeal.id} className="rounded-xl border border-slate-800 bg-slate-950/60 p-4 text-sm text-slate-200">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <span>پیام: {appeal.messageId}</span>
+                  <StatusBadge status={appeal.status} />
+                </div>
+                <p className="mt-2 text-slate-300">دلیل: {appeal.reason}</p>
+                {appeal.resolutionNotes && (
+                  <p className="mt-2 text-slate-400">یادداشت ادمین: {appeal.resolutionNotes}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {isAdmin && (
+        <section className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-5">
+          <header className="space-y-2">
+            <h2 className="text-xl font-semibold">پنل بررسی ادمین</h2>
+            <div className="flex flex-wrap gap-3 text-sm">
+              <select
+                value={adminFilters.role ?? ''}
+                onChange={(event) =>
+                  setAdminFilters((prev) => ({ ...prev, role: event.target.value ? (event.target.value as Role) : undefined }))
+                }
+                className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100"
+              >
+                <option value="">همه نقش‌ها</option>
+                <option value="participant">شرکت‌کننده</option>
+                <option value="mentor">منتور</option>
+                <option value="judge">داور</option>
+                <option value="investor">سرمایه‌گذار</option>
+                <option value="admin">ادمین</option>
+              </select>
+              <select
+                value={adminFilters.status ?? ''}
+                onChange={(event) =>
+                  setAdminFilters((prev) => ({
+                    ...prev,
+                    status: event.target.value ? (event.target.value as AppealStatus) : undefined
+                  }))
+                }
+                className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100"
+              >
+                <option value="">همه وضعیت‌ها</option>
+                <option value="Pending">در انتظار بررسی</option>
+                <option value="Accepted">پذیرفته شد</option>
+                <option value="Rejected">رد شد</option>
+              </select>
+            </div>
+          </header>
+          {adminAppeals.length === 0 ? (
+            <p className="text-sm text-slate-400">اعتراضی برای این فیلتر یافت نشد.</p>
+          ) : (
+            <ul className="space-y-4">
+              {adminAppeals.map((appeal) => (
+                <li key={appeal.id} className="rounded-xl border border-slate-800 bg-slate-950/60 p-4 text-sm text-slate-200">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p>پیام: {appeal.messageId}</p>
+                      <p className="text-slate-400">کاربر: {appeal.userId}</p>
+                    </div>
+                    <StatusBadge status={appeal.status} />
+                  </div>
+                  <p className="mt-2 text-slate-300">دلیل کاربر: {appeal.reason}</p>
+                  <div className="mt-3 flex gap-2">
+                    <button
+                      onClick={() => handleResolve(appeal.id, 'Accepted')}
+                      className="rounded-lg border border-emerald-600 px-3 py-1 text-xs text-emerald-200"
+                    >
+                      تایید اعتراض
+                    </button>
+                    <button
+                      onClick={() => handleResolve(appeal.id, 'Rejected')}
+                      className="rounded-lg border border-rose-600 px-3 py-1 text-xs text-rose-200"
+                    >
+                      رد اعتراض
+                    </button>
+                  </div>
+                  {appeal.reviewedBy && (
+                    <p className="mt-2 text-xs text-slate-500">
+                      بررسی توسط: {appeal.reviewedBy} — {appeal.reviewedAt && new Date(appeal.reviewedAt).toLocaleString('fa-IR')}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: AppealStatus }) {
+  const styles: Record<AppealStatus, string> = {
+    Pending: 'bg-amber-900/40 text-amber-200',
+    Accepted: 'bg-emerald-900/40 text-emerald-200',
+    Rejected: 'bg-rose-900/40 text-rose-200'
+  };
+  const labels: Record<AppealStatus, string> = {
+    Pending: 'در انتظار بررسی',
+    Accepted: 'پذیرفته شد',
+    Rejected: 'رد شد'
+  };
+  return <span className={`rounded-full px-2 py-1 text-xs ${styles[status]}`}>{labels[status]}</span>;
+}

--- a/frontend/components/chat-panel.tsx
+++ b/frontend/components/chat-panel.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import Link from 'next/link';
+import { fetchMessages, MessageModel, Role, sendMessage } from '../lib/api';
+import { useRole } from '../lib/use-role';
+
+const roleLabels: Record<Role, string> = {
+  participant: 'شرکت‌کننده',
+  judge: 'داور',
+  mentor: 'منتور',
+  investor: 'سرمایه‌گذار',
+  admin: 'ادمین'
+};
+
+export function ChatPanel() {
+  const role = useRole();
+  const { data: session, status } = useSession();
+  const accessToken = session?.accessToken;
+  const sessionUser = session?.user
+    ? {
+        id: session.user.id ?? session.user.email ?? null,
+        email: session.user.email ?? null,
+        name: session.user.name ?? null,
+        roles: session.user.roles ?? null
+      }
+    : undefined;
+  const isAuthenticated = status === 'authenticated';
+  const [content, setContent] = useState('');
+  const [messages, setMessages] = useState<MessageModel[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [appealId, setAppealId] = useState<string | null>(null);
+
+  const hasAuth = Boolean(accessToken) || Boolean(sessionUser?.id);
+  const canSend = isAuthenticated && hasAuth && content.trim().length > 0 && !loading;
+  const auth = useMemo(
+    () => ({ accessToken, sessionUser }),
+    [accessToken, sessionUser?.id, sessionUser?.email, sessionUser?.name, sessionUser?.roles?.join(',')]
+  );
+
+  const loadMessages = async () => {
+    if (!isAuthenticated || !hasAuth) {
+      return;
+    }
+    try {
+      const data = await fetchMessages(role, auth);
+      setMessages(data);
+    } catch (error) {
+      setFeedback((error as Error).message);
+    }
+  };
+
+  useEffect(() => {
+    setMessages([]);
+    setFeedback(null);
+    setAppealId(null);
+    if (!hasAuth) {
+      return;
+    }
+    loadMessages();
+    const interval = setInterval(loadMessages, 5000);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [role, auth, accessToken, isAuthenticated, hasAuth]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSend) {
+      return;
+    }
+    setLoading(true);
+    setFeedback(null);
+    try {
+      const response = await sendMessage(role, content, auth);
+      setFeedback(
+        response.rateLimitMessage ??
+          `${response.moderationNotes ?? ''} (ریسک: ${(response.moderationRisk * 100).toFixed(0)}%, امتیاز منفی: ${response.penaltyPoints})`
+      );
+      setContent('');
+      setAppealId(response.status === 'Blocked' ? response.messageId : null);
+      await loadMessages();
+    } catch (error) {
+      setFeedback((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const appealBanner = useMemo(() => {
+    if (!appealId) {
+      return null;
+    }
+    return (
+      <div className="rounded-xl border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-100">
+        پیام اخیر شما مسدود شد. برای ثبت اعتراض می‌توانید شناسه <code className="font-mono">{appealId}</code> را در صفحه{' '}
+        <Link href="/appeals" className="font-semibold text-rose-200 underline">
+          مدیریت اعتراض‌ها
+        </Link>{' '}
+        وارد کنید.
+      </div>
+    );
+  }, [appealId]);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold">کانال {roleLabels[role]}</h1>
+            <p className="text-slate-400 text-sm">
+              پیام‌ها پیش از انتشار توسط موتور Gemini ارزیابی می‌شوند. خروجی شامل وضعیت، امتیاز ریسک و هشدارها است.
+            </p>
+          </div>
+          <div className="text-right text-xs text-slate-400">
+            <p>کاربر: {session?.user?.email ?? session?.user?.name ?? '---'}</p>
+          </div>
+        </div>
+        {appealBanner}
+      </header>
+
+      <div className="rounded-2xl border border-slate-800 bg-slate-900/70">
+        <div className="max-h-[420px] overflow-y-auto divide-y divide-slate-800/60">
+          {messages.length === 0 ? (
+            <p className="p-6 text-sm text-slate-400">هنوز پیامی ارسال نشده است.</p>
+          ) : (
+            messages.map((message) => (
+              <article key={message.id} className="p-5 space-y-2">
+                <div className="flex justify-between text-xs text-slate-500">
+                  <span>کاربر: {message.senderUserId}</span>
+                  <span>{new Date(message.createdAt).toLocaleString('fa-IR')}</span>
+                </div>
+                <p className="text-sm leading-6 text-slate-100 whitespace-pre-wrap">{message.content}</p>
+                <footer className="flex flex-wrap gap-2 text-xs">
+                  <StatusBadge status={message.status} />
+                  <span className="rounded-full bg-slate-800 px-2 py-1">ریسک: {(message.moderationRisk * 100).toFixed(0)}%</span>
+                  {message.moderationTags.map((tag) => (
+                    <span key={tag} className="rounded-full bg-indigo-900/40 px-2 py-1 text-indigo-200">
+                      #{tag}
+                    </span>
+                  ))}
+                  {message.penaltyPoints !== 0 && (
+                    <span className="rounded-full bg-rose-900/40 px-2 py-1 text-rose-200">امتیاز منفی: {message.penaltyPoints}</span>
+                  )}
+                </footer>
+              </article>
+            ))
+          )}
+        </div>
+        <form onSubmit={handleSubmit} className="border-t border-slate-800 p-5 space-y-3">
+          <textarea
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-3 text-sm text-slate-100"
+            placeholder="پیام خود را بنویسید..."
+            rows={3}
+            disabled={!hasAuth}
+          />
+          <div className="flex items-center justify-between text-xs text-slate-400">
+            <span>حداکثر 20 پیام در 5 دقیقه برای نقش شرکت‌کننده مجاز است.</span>
+            <button
+              type="submit"
+              disabled={!canSend}
+              className="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-medium text-emerald-950 disabled:opacity-60"
+            >
+              {loading ? 'در حال ارسال...' : 'ارسال پیام'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {feedback && <p className="text-sm text-amber-300">{feedback}</p>}
+      {(!isAuthenticated || !hasAuth) && (
+        <p className="text-sm text-rose-200">
+          برای ارسال پیام لازم است ابتدا از طریق SSO وارد شوید.{' '}
+          <Link href="/auth/signin" className="underline">
+            صفحه ورود
+          </Link>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: MessageModel['status'] }) {
+  const styles: Record<MessageModel['status'], string> = {
+    Published: 'bg-emerald-900/50 text-emerald-200',
+    Held: 'bg-amber-900/40 text-amber-200',
+    Blocked: 'bg-rose-900/50 text-rose-100'
+  };
+  const labels: Record<MessageModel['status'], string> = {
+    Published: 'منتشر شد',
+    Held: 'در انتظار بررسی',
+    Blocked: 'مسدود شد'
+  };
+
+  return <span className={`rounded-full px-2 py-1 text-xs ${styles[status]}`}>{labels[status]}</span>;
+}

--- a/frontend/components/chat-panel.tsx
+++ b/frontend/components/chat-panel.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { HubConnection } from '@microsoft/signalr';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { fetchMessages, MessageModel, Role, sendMessage } from '../lib/api';
+import { createChatConnection } from '../lib/chat-hub';
 import { useRole } from '../lib/use-role';
 
 const roleLabels: Record<Role, string> = {
@@ -30,8 +32,10 @@ export function ChatPanel() {
   const [content, setContent] = useState('');
   const [messages, setMessages] = useState<MessageModel[]>([]);
   const [loading, setLoading] = useState(false);
+  const [historyLoading, setHistoryLoading] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [appealId, setAppealId] = useState<string | null>(null);
+  const [connectionState, setConnectionState] = useState<'disconnected' | 'connecting' | 'connected'>('disconnected');
 
   const hasAuth = Boolean(accessToken) || Boolean(sessionUser?.id);
   const canSend = isAuthenticated && hasAuth && content.trim().length > 0 && !loading;
@@ -39,31 +43,108 @@ export function ChatPanel() {
     () => ({ accessToken, sessionUser }),
     [accessToken, sessionUser?.id, sessionUser?.email, sessionUser?.name, sessionUser?.roles?.join(',')]
   );
+  const authSignature = useMemo(() => {
+    if (accessToken) {
+      return `token:${accessToken}`;
+    }
+    if (!sessionUser) {
+      return 'guest';
+    }
+    const descriptor = [sessionUser.id, sessionUser.email, sessionUser.name, (sessionUser.roles ?? []).join(',')]
+      .filter(Boolean)
+      .join('|');
+    return `debug:${descriptor}`;
+  }, [accessToken, sessionUser?.id, sessionUser?.email, sessionUser?.name, sessionUser?.roles?.join(',')]);
 
-  const loadMessages = async () => {
-    if (!isAuthenticated || !hasAuth) {
-      return;
-    }
-    try {
-      const data = await fetchMessages(role, auth);
-      setMessages(data);
-    } catch (error) {
-      setFeedback((error as Error).message);
-    }
-  };
+  const currentUserId = useMemo(
+    () => sessionUser?.id ?? sessionUser?.email ?? sessionUser?.name ?? null,
+    [sessionUser?.id, sessionUser?.email, sessionUser?.name]
+  );
+
+  const upsertMessage = useCallback(
+    (incoming: MessageModel) => {
+      setMessages((prev) => {
+        const next = prev.filter((m) => m.id !== incoming.id);
+        if (incoming.status !== 'Blocked') {
+          next.push(incoming);
+          next.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+        }
+        return next;
+      });
+
+      if (currentUserId && incoming.senderUserId === currentUserId) {
+        setFeedback(
+          `${incoming.moderationNotes ?? 'نتیجه بررسی در دسترس است.'} (ریسک: ${(incoming.moderationRisk * 100).toFixed(0)}%, امتیاز منفی: ${incoming.penaltyPoints})`
+        );
+        setAppealId(incoming.status === 'Blocked' ? incoming.id : null);
+      }
+    },
+    [currentUserId]
+  );
 
   useEffect(() => {
     setMessages([]);
     setFeedback(null);
     setAppealId(null);
+
     if (!hasAuth) {
+      setConnectionState('disconnected');
+      setHistoryLoading(false);
       return;
     }
-    loadMessages();
-    const interval = setInterval(loadMessages, 5000);
-    return () => clearInterval(interval);
+
+    let active = true;
+    let connection: HubConnection | null = null;
+
+    const bootstrap = async () => {
+      setConnectionState('connecting');
+      setHistoryLoading(true);
+      try {
+        const history = await fetchMessages(role, auth);
+        if (active) {
+          setMessages(history);
+        }
+      } catch (error) {
+        if (active) {
+          setFeedback((error as Error).message);
+        }
+      } finally {
+        if (active) {
+          setHistoryLoading(false);
+        }
+      }
+
+      try {
+        connection = await createChatConnection(role, auth, upsertMessage);
+        if (!active) {
+          await connection.stop();
+          return;
+        }
+
+        setConnectionState('connected');
+        connection.onclose(() => setConnectionState('disconnected'));
+        connection.onreconnecting(() => setConnectionState('connecting'));
+        connection.onreconnected(() => setConnectionState('connected'));
+      } catch (error) {
+        if (active) {
+          setConnectionState('disconnected');
+          setFeedback((error as Error).message);
+        }
+      }
+    };
+
+    bootstrap();
+
+    return () => {
+      active = false;
+      setConnectionState('disconnected');
+      if (connection) {
+        connection.off('MessageUpserted', upsertMessage);
+        connection.stop().catch(() => undefined);
+      }
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [role, auth, accessToken, isAuthenticated, hasAuth]);
+  }, [role, hasAuth, authSignature, upsertMessage]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -72,15 +153,27 @@ export function ChatPanel() {
     }
     setLoading(true);
     setFeedback(null);
+    setAppealId(null);
     try {
       const response = await sendMessage(role, content, auth);
+      const placeholder: MessageModel = {
+        id: response.messageId,
+        channel: role,
+        senderUserId: currentUserId ?? 'self',
+        content,
+        createdAt: new Date().toISOString(),
+        status: response.status,
+        moderationRisk: response.moderationRisk,
+        moderationTags: response.moderationTags,
+        moderationNotes: response.moderationNotes,
+        penaltyPoints: response.penaltyPoints
+      };
+      upsertMessage(placeholder);
       setFeedback(
         response.rateLimitMessage ??
-          `${response.moderationNotes ?? ''} (ریسک: ${(response.moderationRisk * 100).toFixed(0)}%, امتیاز منفی: ${response.penaltyPoints})`
+          `${response.moderationNotes ?? 'پیام برای بررسی ارسال شد.'} (ریسک: ${(response.moderationRisk * 100).toFixed(0)}%, امتیاز منفی: ${response.penaltyPoints})`
       );
       setContent('');
-      setAppealId(response.status === 'Blocked' ? response.messageId : null);
-      await loadMessages();
     } catch (error) {
       setFeedback((error as Error).message);
     } finally {
@@ -122,7 +215,9 @@ export function ChatPanel() {
 
       <div className="rounded-2xl border border-slate-800 bg-slate-900/70">
         <div className="max-h-[420px] overflow-y-auto divide-y divide-slate-800/60">
-          {messages.length === 0 ? (
+          {historyLoading && messages.length === 0 ? (
+            <p className="p-6 text-sm text-slate-400">در حال بارگذاری پیام‌های قبلی...</p>
+          ) : messages.length === 0 ? (
             <p className="p-6 text-sm text-slate-400">هنوز پیامی ارسال نشده است.</p>
           ) : (
             messages.map((message) => (
@@ -171,6 +266,15 @@ export function ChatPanel() {
       </div>
 
       {feedback && <p className="text-sm text-amber-300">{feedback}</p>}
+      <p className="text-xs text-slate-500">
+        وضعیت اتصال: {
+          {
+            connected: 'متصل',
+            connecting: 'در حال اتصال...',
+            disconnected: 'قطع'
+          }[connectionState]
+        }
+      </p>
       {(!isAuthenticated || !hasAuth) && (
         <p className="text-sm text-rose-200">
           برای ارسال پیام لازم است ابتدا از طریق SSO وارد شوید.{' '}

--- a/frontend/components/knowledge-base-manager.tsx
+++ b/frontend/components/knowledge-base-manager.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import Link from 'next/link';
+import {
+  deleteKnowledgeBaseItem,
+  fetchKnowledgeBase,
+  KnowledgeBaseItem,
+  upsertKnowledgeBaseItem
+} from '../lib/api';
+
+interface EditorState {
+  id?: string;
+  title: string;
+  body: string;
+  audience: string;
+  tags: string;
+}
+
+const initialState: EditorState = {
+  title: '',
+  body: '',
+  audience: 'all',
+  tags: ''
+};
+
+export function KnowledgeBaseManager() {
+  const { data: session } = useSession();
+  const accessToken = session?.accessToken;
+  const sessionUser = session?.user
+    ? {
+        id: session.user.id ?? session.user.email ?? null,
+        email: session.user.email ?? null,
+        name: session.user.name ?? null,
+        roles: session.user.roles ?? null
+      }
+    : undefined;
+  const auth = useMemo(
+    () => ({ accessToken, sessionUser }),
+    [accessToken, sessionUser?.id, sessionUser?.email, sessionUser?.name, sessionUser?.roles?.join(',')]
+  );
+  const isAdmin = (session?.user?.roles ?? []).includes('admin');
+  const [items, setItems] = useState<KnowledgeBaseItem[]>([]);
+  const [editor, setEditor] = useState<EditorState>(initialState);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      setItems([]);
+      return;
+    }
+
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchKnowledgeBase(auth);
+        if (!cancelled) {
+          setItems(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError((err as Error).message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [auth, isAdmin]);
+
+  const audiences = useMemo(
+    () => [
+      { value: 'all', label: 'همه نقش‌ها' },
+      { value: 'participant', label: 'شرکت‌کنندگان' },
+      { value: 'mentor', label: 'منتورها' },
+      { value: 'judge', label: 'داوران' },
+      { value: 'investor', label: 'سرمایه‌گذاران' },
+      { value: 'admin', label: 'ادمین‌ها' }
+    ],
+    []
+  );
+
+  const handleReset = () => {
+    setEditor(initialState);
+    setSuccess(null);
+    setError(null);
+  };
+
+  const handleEdit = (item: KnowledgeBaseItem) => {
+    setEditor({
+      id: item.id,
+      title: item.title,
+      body: item.body,
+      audience: item.audience,
+      tags: item.tags.join(', ')
+    });
+    setSuccess(null);
+    setError(null);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('آیا از حذف این منبع مطمئن هستید؟')) {
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await deleteKnowledgeBaseItem(id, auth);
+      setItems((prev) => prev.filter((item) => item.id !== id));
+      if (editor.id === id) {
+        handleReset();
+      }
+      setSuccess('منبع با موفقیت حذف شد.');
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editor.title.trim() || !editor.body.trim()) {
+      setError('عنوان و محتوای منبع اجباری است.');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const payload = {
+        id: editor.id,
+        title: editor.title.trim(),
+        body: editor.body.trim(),
+        audience: editor.audience,
+        tags: editor.tags
+          .split(',')
+          .map((tag) => tag.trim())
+          .filter(Boolean)
+      };
+      const saved = await upsertKnowledgeBaseItem(payload, auth);
+      setItems((prev) => {
+        const exists = prev.find((item) => item.id === saved.id);
+        if (exists) {
+          return prev.map((item) => (item.id === saved.id ? saved : item));
+        }
+        return [saved, ...prev];
+      });
+      setEditor({
+        id: saved.id,
+        title: saved.title,
+        body: saved.body,
+        audience: saved.audience,
+        tags: saved.tags.join(', ')
+      });
+      setSuccess('منبع ذخیره شد.');
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <div className="rounded-2xl border border-amber-500/40 bg-amber-500/10 p-6 text-sm text-amber-100">
+        دسترسی به مدیریت دانش تنها برای ادمین‌ها فراهم است. در صورت نیاز لطفاً با تیم پشتیبانی تماس بگیرید یا{' '}
+        <Link href="/auth/signin" className="underline">
+          با حساب کاربری دیگری وارد شوید
+        </Link>
+        .
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[2fr_3fr]">
+      <section className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-5">
+        <header className="space-y-2">
+          <h2 className="text-xl font-semibold">افزودن / ویرایش منبع دانش</h2>
+          <p className="text-sm text-slate-400">
+            منابع منتشرشده در اینجا به‌صورت خودکار برای چت پشتیبانی قابل استفاده است. نقش هدف و برچسب‌ها را دقیق وارد کنید.
+          </p>
+        </header>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-slate-300">عنوان</span>
+            <input
+              className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100"
+              value={editor.title}
+              onChange={(event) => setEditor((prev) => ({ ...prev, title: event.target.value }))}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-slate-300">مخاطب</span>
+            <select
+              className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100"
+              value={editor.audience}
+              onChange={(event) => setEditor((prev) => ({ ...prev, audience: event.target.value }))}
+            >
+              {audiences.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-slate-300">برچسب‌ها (با کاما جدا کنید)</span>
+            <input
+              className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100"
+              value={editor.tags}
+              onChange={(event) => setEditor((prev) => ({ ...prev, tags: event.target.value }))}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-slate-300">متن پاسخ</span>
+            <textarea
+              className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-3 text-sm text-slate-100"
+              rows={6}
+              value={editor.body}
+              onChange={(event) => setEditor((prev) => ({ ...prev, body: event.target.value }))}
+            />
+          </label>
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-medium text-emerald-950 disabled:opacity-60"
+            >
+              {saving ? 'در حال ذخیره...' : 'ذخیره منبع'}
+            </button>
+            <button
+              type="button"
+              onClick={handleReset}
+              className="rounded-lg border border-slate-600 px-4 py-2 text-sm text-slate-200"
+            >
+              ایجاد منبع جدید
+            </button>
+          </div>
+          {success && <p className="text-sm text-emerald-300">{success}</p>}
+          {error && <p className="text-sm text-rose-300">{error}</p>}
+        </form>
+      </section>
+
+      <section className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-5">
+        <header className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold">منابع موجود</h2>
+          {loading && <span className="text-xs text-slate-400">در حال بارگذاری...</span>}
+        </header>
+        {items.length === 0 ? (
+          <p className="text-sm text-slate-400">منبعی ثبت نشده است.</p>
+        ) : (
+          <ul className="space-y-4">
+            {items.map((item) => (
+              <li key={item.id} className="rounded-xl border border-slate-800 bg-slate-950/60 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3 text-sm">
+                  <div>
+                    <h3 className="text-lg font-semibold text-slate-100">{item.title}</h3>
+                    <p className="text-slate-400">مخاطب: {item.audience}</p>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => handleEdit(item)}
+                      className="rounded-lg border border-slate-600 px-3 py-1 text-xs text-slate-200"
+                    >
+                      ویرایش
+                    </button>
+                    <button
+                      onClick={() => handleDelete(item.id)}
+                      className="rounded-lg border border-rose-600 px-3 py-1 text-xs text-rose-200"
+                    >
+                      حذف
+                    </button>
+                  </div>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-slate-100 whitespace-pre-wrap">{item.body}</p>
+                {item.tags.length > 0 && (
+                  <div className="mt-3 flex flex-wrap gap-2 text-xs text-indigo-200">
+                    {item.tags.map((tag) => (
+                      <span key={tag} className="rounded-full bg-indigo-900/40 px-2 py-1">
+                        #{tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/components/role-switcher.tsx
+++ b/frontend/components/role-switcher.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useRoleSelection } from '../lib/use-role';
+import type { Role } from '../lib/api';
+
+const roleLabels: Record<Role, string> = {
+  participant: 'شرکت‌کننده',
+  judge: 'داور',
+  mentor: 'منتور',
+  investor: 'سرمایه‌گذار',
+  admin: 'ادمین'
+};
+
+export function RoleSwitcher() {
+  const { role, roles, setRole } = useRoleSelection();
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 text-sm">
+      <span className="text-slate-400">نقش فعال:</span>
+      <div className="flex flex-wrap gap-2">
+        {roles.map((item) => (
+          <button
+            key={item}
+            onClick={() => setRole(item)}
+            className={`rounded-full border px-3 py-1 transition ${
+              role === item ? 'border-emerald-400 bg-emerald-500/20 text-emerald-100' : 'border-slate-700 bg-slate-800'
+            }`}
+          >
+            {roleLabels[item] ?? item}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/support-panel.tsx
+++ b/frontend/components/support-panel.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import Link from 'next/link';
+import { askSupport, Role, SupportAnswer } from '../lib/api';
+import { useRole } from '../lib/use-role';
+
+export function SupportPanel() {
+  const role = useRole() as Role;
+  const { data: session, status } = useSession();
+  const accessToken = session?.accessToken;
+  const sessionUser = session?.user
+    ? {
+        id: session.user.id ?? session.user.email ?? null,
+        email: session.user.email ?? null,
+        name: session.user.name ?? null,
+        roles: session.user.roles ?? null
+      }
+    : undefined;
+  const isAuthenticated = status === 'authenticated';
+  const [question, setQuestion] = useState('قوانین عمومی رویداد چیست؟');
+  const [answer, setAnswer] = useState<SupportAnswer | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const hasAuth = Boolean(accessToken) || Boolean(sessionUser?.id);
+  const auth = useMemo(
+    () => ({ accessToken, sessionUser }),
+    [accessToken, sessionUser?.id, sessionUser?.email, sessionUser?.name, sessionUser?.roles?.join(',')]
+  );
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!question.trim() || !isAuthenticated || !hasAuth) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await askSupport({ role, question }, auth);
+      setAnswer(result);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">پشتیبانی هوشمند</h1>
+        <p className="text-slate-400 text-sm">
+          پاسخ‌ها از دانش‌پایه‌ی منتشر شده توسط ادمین و منابع داخلی تامین می‌شود. در صورت اطمینان پایین، پیشنهاد تماس انسانی ارائه می‌گردد.
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-5">
+        <div className="grid gap-4 md:grid-cols-2 text-sm text-slate-400">
+          <div>
+            <span>کاربر جاری</span>
+            <p className="mt-1 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100">
+              {session?.user?.email ?? session?.user?.name ?? '---'}
+            </p>
+          </div>
+          <div>
+            <span>نقش فعال</span>
+            <p className="mt-1 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100">{role}</p>
+          </div>
+        </div>
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="text-slate-400">سوال شما</span>
+          <textarea
+            value={question}
+            onChange={(event) => setQuestion(event.target.value)}
+            rows={4}
+            className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-3 text-sm text-slate-100"
+            disabled={!isAuthenticated || !hasAuth}
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={loading || !isAuthenticated || !hasAuth}
+          className="rounded-lg bg-sky-500 px-4 py-2 text-sm font-medium text-sky-950 disabled:opacity-60"
+        >
+          {loading ? 'در حال تحلیل...' : 'ارسال سوال'}
+        </button>
+      </form>
+
+      {answer && (
+        <section className="space-y-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-5">
+          <header className="flex flex-wrap items-center justify-between gap-3 text-sm">
+            <div className="flex items-center gap-2">
+              <span className="rounded-full bg-emerald-900/40 px-2 py-1 text-emerald-200">
+                اطمینان: {(answer.confidence * 100).toFixed(0)}%
+              </span>
+              {answer.escalateToHuman && (
+                <span className="rounded-full bg-amber-900/40 px-2 py-1 text-amber-200">پیشنهاد ارتباط انسانی</span>
+              )}
+            </div>
+            {answer.sources?.length > 0 && (
+              <div className="text-xs text-slate-400">منابع: {answer.sources.join(', ')}</div>
+            )}
+          </header>
+          <p className="leading-7 text-slate-100 whitespace-pre-wrap">{answer.answer}</p>
+        </section>
+      )}
+
+      {error && <p className="text-sm text-rose-300">{error}</p>}
+      {(!isAuthenticated || !hasAuth) && (
+        <p className="text-sm text-rose-200">
+          برای استفاده از پشتیبانی لازم است ابتدا{' '}
+          <Link href="/auth/signin" className="underline">
+            وارد سامانه شوید
+          </Link>
+          .
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,6 +1,6 @@
 export type Role = 'participant' | 'judge' | 'mentor' | 'investor' | 'admin';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:5000';
+export const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:5000';
 
 export interface SessionUserInfo {
   id?: string | null;
@@ -227,4 +227,32 @@ function applyAuthHeaders(headers: Headers, auth?: AuthContext) {
   if (roles.length > 0) {
     headers.set('X-Debug-Roles', roles.join(','));
   }
+}
+
+export function buildDebugQuery(auth?: AuthContext): URLSearchParams {
+  const params = new URLSearchParams();
+  if (!auth || auth.accessToken) {
+    return params;
+  }
+
+  const user = auth.sessionUser;
+  if (!user) {
+    return params;
+  }
+
+  const debugId = user.id ?? user.email ?? user.name ?? null;
+  if (debugId) {
+    params.set('debug_user', String(debugId));
+  }
+
+  if (user.email) {
+    params.set('debug_email', String(user.email));
+  }
+
+  const roles = Array.isArray(user.roles) ? user.roles.filter(Boolean) : [];
+  if (roles.length > 0) {
+    params.set('debug_roles', roles.join(','));
+  }
+
+  return params;
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,230 @@
+export type Role = 'participant' | 'judge' | 'mentor' | 'investor' | 'admin';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:5000';
+
+export interface SessionUserInfo {
+  id?: string | null;
+  email?: string | null;
+  name?: string | null;
+  roles?: string[] | null;
+}
+
+export interface AuthContext {
+  accessToken?: string;
+  sessionUser?: SessionUserInfo | null;
+}
+
+type FetchOptions = RequestInit & AuthContext;
+
+async function apiFetch<T>(path: string, options: FetchOptions = {}): Promise<T> {
+  const { accessToken, sessionUser, headers, ...init } = options;
+  const combinedHeaders = new Headers(headers);
+  combinedHeaders.set('Content-Type', combinedHeaders.get('Content-Type') ?? 'application/json');
+  applyAuthHeaders(combinedHeaders, { accessToken, sessionUser });
+
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: combinedHeaders,
+    cache: 'no-store'
+  });
+
+  if (!response.ok) {
+    const body = await safeReadJson(response);
+    throw new Error((body as any)?.message ?? 'خطا در ارتباط با سرور');
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+async function safeReadJson(response: Response) {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+export interface SendMessageResponse {
+  messageId: string;
+  status: 'Published' | 'Held' | 'Blocked';
+  moderationRisk: number;
+  moderationTags: string[];
+  moderationNotes?: string | null;
+  penaltyPoints: number;
+  softWarn: boolean;
+  rateLimitMessage?: string | null;
+}
+
+export interface MessageModel {
+  id: string;
+  channel: Role;
+  senderUserId: string;
+  content: string;
+  createdAt: string;
+  status: 'Published' | 'Held' | 'Blocked';
+  moderationRisk: number;
+  moderationTags: string[];
+  moderationNotes?: string | null;
+  penaltyPoints: number;
+}
+
+export interface SupportAnswer {
+  answer: string;
+  sources: string[];
+  confidence: number;
+  escalateToHuman: boolean;
+}
+
+export interface KnowledgeBaseItem {
+  id: string;
+  title: string;
+  body: string;
+  audience: string;
+  tags: string[];
+  updatedAt: string;
+}
+
+export type AppealStatus = 'Pending' | 'Accepted' | 'Rejected';
+
+export interface Appeal {
+  id: string;
+  messageId: string;
+  channel: Role;
+  userId: string;
+  submittedAt: string;
+  reason: string;
+  status: AppealStatus;
+  resolutionNotes?: string | null;
+  reviewedBy?: string | null;
+  reviewedAt?: string | null;
+}
+
+export async function fetchMessages(role: Role, auth?: AuthContext): Promise<MessageModel[]> {
+  const data = await apiFetch<{ messages: MessageModel[] }>(`/api/chat/${role}/messages`, auth);
+  return data.messages ?? [];
+}
+
+export async function sendMessage(role: Role, content: string, auth?: AuthContext): Promise<SendMessageResponse> {
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  applyAuthHeaders(headers, auth);
+  const response = await fetch(`${API_BASE}/api/chat/${role}/messages`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ content }),
+    cache: 'no-store'
+  });
+
+  const body = await safeReadJson(response);
+  if (response.ok || response.status === 202 || response.status === 403 || response.status === 429) {
+    return body as SendMessageResponse;
+  }
+
+  throw new Error((body as any)?.message ?? 'ارسال پیام ناموفق بود');
+}
+
+export async function askSupport(payload: { role: Role; question: string }, auth?: AuthContext): Promise<SupportAnswer> {
+  return apiFetch<SupportAnswer>(`/api/support/query`, {
+    method: 'POST',
+    ...auth,
+    body: JSON.stringify(payload)
+  });
+}
+
+export async function fetchKnowledgeBase(auth?: AuthContext): Promise<KnowledgeBaseItem[]> {
+  return apiFetch<KnowledgeBaseItem[]>(`/api/knowledge-base`, auth);
+}
+
+export async function upsertKnowledgeBaseItem(
+  item: Partial<KnowledgeBaseItem> & { title: string; body: string; audience?: string; tags?: string[] },
+  auth?: AuthContext
+): Promise<KnowledgeBaseItem> {
+  return apiFetch<KnowledgeBaseItem>(`/api/knowledge-base`, {
+    method: 'POST',
+    ...auth,
+    body: JSON.stringify(item)
+  });
+}
+
+export async function deleteKnowledgeBaseItem(id: string, auth?: AuthContext): Promise<void> {
+  await apiFetch<void>(`/api/knowledge-base/${id}`, {
+    method: 'DELETE',
+    ...auth
+  });
+}
+
+export async function fetchAppeals(auth?: AuthContext): Promise<Appeal[]> {
+  return apiFetch<Appeal[]>(`/api/appeals`, auth);
+}
+
+export async function createAppeal(payload: { messageId: string; reason: string }, auth?: AuthContext): Promise<Appeal> {
+  return apiFetch<Appeal>(`/api/appeals`, {
+    method: 'POST',
+    ...auth,
+    body: JSON.stringify(payload)
+  });
+}
+
+export async function queryAppeals(
+  auth: AuthContext | undefined,
+  filters: { role?: Role; status?: AppealStatus } = {}
+): Promise<Appeal[]> {
+  const search = new URLSearchParams();
+  if (filters.role) {
+    search.set('role', filters.role);
+  }
+  if (filters.status) {
+    search.set('status', filters.status);
+  }
+  const query = search.toString();
+  return apiFetch<Appeal[]>(`/api/appeals/admin${query ? `?${query}` : ''}`, auth);
+}
+
+export async function resolveAppeal(
+  id: string,
+  payload: { status: AppealStatus; notes?: string },
+  auth?: AuthContext
+): Promise<Appeal> {
+  return apiFetch<Appeal>(`/api/appeals/${id}/decision`, {
+    method: 'POST',
+    ...auth,
+    body: JSON.stringify(payload)
+  });
+}
+
+export async function fetchDiscipline(role: Role, auth?: AuthContext): Promise<any> {
+  return apiFetch(`/api/discipline/${role}/me`, auth);
+}
+
+function applyAuthHeaders(headers: Headers, auth?: AuthContext) {
+  if (!auth) {
+    return;
+  }
+
+  if (auth.accessToken) {
+    headers.set('Authorization', `Bearer ${auth.accessToken}`);
+    return;
+  }
+
+  const user = auth.sessionUser;
+  if (!user) {
+    return;
+  }
+
+  const debugId = user.id ?? user.email ?? user.name ?? null;
+  if (debugId) {
+    headers.set('X-Debug-User', String(debugId));
+  }
+
+  if (user.email) {
+    headers.set('X-Debug-Email', String(user.email));
+  }
+
+  const roles = Array.isArray(user.roles) ? user.roles.filter(Boolean) : [];
+  if (roles.length > 0) {
+    headers.set('X-Debug-Roles', roles.join(','));
+  }
+}

--- a/frontend/lib/chat-hub.ts
+++ b/frontend/lib/chat-hub.ts
@@ -1,0 +1,36 @@
+import { HubConnection, HubConnectionBuilder, HttpTransportType, LogLevel } from '@microsoft/signalr';
+import { API_BASE, AuthContext, MessageModel, Role, buildDebugQuery } from './api';
+
+export type MessageListener = (message: MessageModel) => void;
+
+export async function createChatConnection(
+  role: Role,
+  auth: AuthContext,
+  listener: MessageListener
+): Promise<HubConnection> {
+  const baseUrl = API_BASE.endsWith('/') ? API_BASE.slice(0, -1) : API_BASE;
+  const url = new URL(`${baseUrl}/hubs/chat`);
+  url.searchParams.set('role', role);
+
+  const debugParams = buildDebugQuery(auth);
+  debugParams.forEach((value, key) => {
+    url.searchParams.set(key, value);
+  });
+
+  const connection = new HubConnectionBuilder()
+    .withUrl(url.toString(), {
+      transport: HttpTransportType.WebSockets | HttpTransportType.LongPolling,
+      accessTokenFactory: auth.accessToken ? () => auth.accessToken! : undefined,
+      withCredentials: true
+    })
+    .withAutomaticReconnect({ nextRetryDelayInMilliseconds: () => 2000 })
+    .configureLogging(LogLevel.Warning)
+    .build();
+
+  connection.on('MessageUpserted', (message: MessageModel) => {
+    listener(message);
+  });
+
+  await connection.start();
+  return connection;
+}

--- a/frontend/lib/role-context.tsx
+++ b/frontend/lib/role-context.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { Role } from './api';
+
+interface RoleContextValue {
+  role: Role;
+  roles: Role[];
+  setRole: (role: Role) => void;
+}
+
+const RoleContext = createContext<RoleContextValue | undefined>(undefined);
+
+export function RoleProvider({ children }: { children: React.ReactNode }) {
+  const { data } = useSession();
+  const rawRoles = useMemo(() => {
+    const claimRoles = (data?.user?.roles ?? []) as string[];
+    if (claimRoles.length > 0) {
+      return claimRoles.map((role) => role.toLowerCase()) as Role[];
+    }
+    return ['participant'] as Role[];
+  }, [data?.user?.roles]);
+
+  const defaultRole = rawRoles[0] ?? 'participant';
+  const [role, setRole] = useState<Role>(defaultRole);
+
+  useEffect(() => {
+    setRole(defaultRole);
+  }, [defaultRole]);
+
+  const value = useMemo(
+    () => ({
+      role,
+      roles: rawRoles,
+      setRole: (next: Role) => {
+        if (rawRoles.includes(next)) {
+          setRole(next);
+        }
+      }
+    }),
+    [role, rawRoles]
+  );
+
+  return <RoleContext.Provider value={value}>{children}</RoleContext.Provider>;
+}
+
+export function useRoleContext() {
+  const context = useContext(RoleContext);
+  if (!context) {
+    throw new Error('useRoleContext must be used within a RoleProvider');
+  }
+  return context;
+}

--- a/frontend/lib/use-role.ts
+++ b/frontend/lib/use-role.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import { useRoleContext } from './role-context';
+
+export function useRole() {
+  return useRoleContext().role;
+}
+
+export function useRoleSelection() {
+  const { role, setRole, roles } = useRoleContext();
+  return { role, setRole, roles };
+}

--- a/frontend/next-auth.d.ts
+++ b/frontend/next-auth.d.ts
@@ -1,0 +1,21 @@
+import NextAuth, { DefaultSession } from 'next-auth';
+import { JWT } from 'next-auth/jwt';
+
+declare module 'next-auth' {
+  interface Session {
+    accessToken?: string;
+    user?: DefaultSession['user'] & {
+      id?: string;
+      roles?: string[];
+    };
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    accessToken?: string;
+    roles?: string[];
+  }
+}
+
+export {};

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,8 @@
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@microsoft/signalr": "8.0.0",
     "next": "14.1.4",
     "next-auth": "4.24.5",
     "react": "18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "nabteams-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.4",
+    "next-auth": "4.24.5",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.19",
+    "@types/react": "18.2.55",
+    "@types/react-dom": "18.2.18",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.4",
+    "typescript": "5.3.3"
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "next-auth.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,0 +1,156 @@
+# Implementation Blueprint: Role-Based Global Chat with Gemini Moderation & Knowledge-Driven Support
+
+این سند تبدیل تحلیل مفهومی به نقشه‌ی اجرایی برای پیاده‌سازی بک‌اند مبتنی بر **.NET 8 (ASP.NET Core)** و فرانت‌اند **Next.js 14 (App Router)** است. هدف، ایجاد چت گلوبال نقش‌محور با پایش هوشمند Gemini و چت پشتیبانی دانشی است.
+
+---
+
+## 1. Architecture Overview
+
+- **Frontend**: Next.js 14، TypeScript، Server Actions، Zustand/Redux Toolkit برای state، Tailwind CSS برای UI، Socket.IO client برای چت زنده.
+- **Backend**: ASP.NET Core 8 Web API، SignalR برای چت real-time، EF Core 8 با PostgreSQL، Redis برای کش و rate limiting، Azure Blob/S3 برای فایل، Background services (Hangfire/Hosted Services) برای پردازش صف.
+- **AI Services**: Google Gemini APIs (`gemini-1.5-flash` برای moderation، `gemini-1.5-pro` + `text-embedding-004` برای RAG).
+- **Infrastructure**: Docker Compose برای dev، CI/CD (GitHub Actions)، Secrets از طریق Azure Key Vault/AWS Secrets Manager.
+
+---
+
+## 2. Domain & Data Design (Backend)
+
+1. **Entities**
+   - `Message`، `Attachment`, `ModerationLog`, `UserDiscipline`, `SupportKnowledgeItem`, `SupportQA`, `Appeal`, `RateLimitEntry`.
+2. **DB Schema Tasks**
+   - ایجاد migration اولیه با جداول و ایندکس مناسب (role_channel, event_id).
+   - افزودن ستون‌های JSON برای `moderation_reasons`, `retrieved_sources`.
+3. **Repositories/Services**
+   - MessageService (CRUD + paging + pinning).
+   - ModerationService (calls Gemini + rule engine).
+   - DisciplineService (score ledger + thresholds).
+   - SupportKnowledgeService (CRUD + search metadata).
+   - SupportChatService (retrieval + logging).
+4. **Vector Store**
+   - استفاده از pgvector یا Redis Stack. جدول `knowledge_vectors` با ستون برداری 1536.
+
+---
+
+## 3. Backend Feature Breakdown (.NET)
+
+### 3.1 Real-time Role Chats
+- SignalR Hub با گروه‌بندی بر اساس `role_channel` و `event_id`.
+- Middleware احراز هویت JWT + claim نقش.
+- API ها:
+  - `POST /api/chats/{role}/messages` (ارسال → صف moderation).
+  - `GET /api/chats/{role}/messages` (pagination، فیلتر event).
+  - `POST /api/chats/{role}/pins` (ادمین/مدیر نقش).
+- Queue (Azure Service Bus/RabbitMQ) برای پردازش async پیام و فراخوانی Gemini در BackgroundService.
+
+### 3.2 Moderation Pipeline
+- Rule Engine اولیه (کلمات ممنوع، لینک‌های blacklist).
+- سرویس Gemini Moderation:
+  - مدل Flash برای پیش‌فرض؛ اگر خروجی «Ambiguous»، دوباره با Pro.
+  - Mapping به سطوح اقدام (Publish/SoftWarn/Hold/Block).
+- ثبت `ModerationLog` + به‌روزرسانی `UserDiscipline`.
+- Webhook یا SignalR event برای اطلاع به کاربر (هشدار، بلاک).
+
+### 3.3 Appeals & Admin Controls
+- API ها برای لیست اعتراض‌ها، تغییر امتیاز، تنظیم Threshold.
+- Dashboard endpoints برای گزارش‌ها (Aggregations با LINQ/SQL).
+
+### 3.4 Support Chat (RAG)
+- API `POST /api/support/ask` → جریان Intent Detection + Retrieval + Generation.
+- ایندکس‌گذاری دانش با Background job (Parse PDFs → Text → Chunk → Embed → Store).
+- ذخیره `SupportQA` با منابع، confidence.
+- Endpoint مدیریت دانش: CRUD با role/event scoping.
+
+### 3.5 Rate Limiting & Anti-Abuse
+- Redis-based sliding window برای پیام‌ها.
+- Flood detector: الگوریتم بررسی تکرار پیام.
+- لینک‌چک با سرویس third-party یا لیست داخلی.
+
+### 3.6 Observability & Auditing
+- Serilog + OpenTelemetry (Tracing, Metrics).
+- Audit Trail middleware برای ثبت تغییرات ادمین و تصمیمات AI.
+
+---
+
+## 4. Frontend Feature Breakdown (Next.js)
+
+### 4.1 Global Chat UI
+- صفحات `/dashboard/[role]/chat` با App Router.
+- استفاده از Server Components برای داده اولیه و Client Components برای real-time.
+- بخش‌های UI:
+  - لیست گفتگو (virtualized list، نمایش status پیام).
+  - Composer با پشتیبانی Emoji، آپلود فایل (Dropzone + presigned URL).
+  - Badge نقش و امتیاز سلامت (discipline score).
+  - بنر سیاست محتوا و لینک اعتراض.
+- مدیریت state پیام‌های Pending/Held با optimistic updates + SignalR client.
+
+### 4.2 Moderation Feedback UX
+- Modal/Toast هشدار با توضیح AI.
+- صفحه `Policy & Appeals` برای مشاهده تاریخچه امتیاز منفی.
+- فرم اعتراض (calls `/api/appeals`).
+
+### 4.3 Support Chat UI
+- صفحه `/support` (دسترسی از سایدبار).
+- Chat-like experience با پیام سیستم/کاربر، نمایش منابع (chips لینک‌دار).
+- وضعیت اعتماد پاسخ (Confidence meter)، پیشنهاد escalate.
+
+### 4.4 Admin Panel Extensions
+- ماژول مدیریت دانش (editor با Markdown، آپلود فایل → indexing job).
+- تنظیم Thresholdها، مشاهده گزارش Heatmap و جدول تخلفات.
+- استفاده از React Query برای داده‌های مدیریتی.
+
+### 4.5 Localization & Accessibility
+- i18n با `next-intl` (فارسی/انگلیسی).
+- RTL پشتیبانی (Tailwind + CSS logical properties).
+- کیبورد ناوبری، ARIA labels.
+
+---
+
+## 5. DevOps & Environment Setup
+
+1. **Local Dev**
+   - Docker Compose: webapi, postgres, redis, vector-db, nextjs, traefik proxy.
+   - Seed scripts برای ایجاد نقش‌ها و داده نمونه.
+2. **CI/CD**
+   - GitHub Actions: build & test .NET، lint & test Next.js، امنیت (Dependabot, Snyk optional).
+   - Deployment به Azure Web App + Static Web App یا AWS (ECS + Amplify).
+3. **Secrets & Config**
+   - استفاده از User Secrets در dev، Key Vault در prod.
+   - ذخیره کلیدهای Gemini و Storage.
+4. **Monitoring**
+   - Application Insights/Datadog برای backend.
+   - Frontend logging با Sentry.
+
+---
+
+## 6. Milestones & Sprints (High-Level)
+
+### Sprint 1 (2 هفته)
+- Setup پروژه‌ها (.NET + Next.js + shared models).
+- طراحی DB و migrations.
+- پیاده‌سازی ابتدایی SignalR chat بدون moderation.
+- UI چت پایه (ارسال/دریافت).
+
+### Sprint 2
+- ادغام Gemini moderation pipeline + امتیاز انضباطی.
+- UI هشدارها، Appeals API & UI.
+- Rate limiting و audit logging.
+
+### Sprint 3
+- RAG pipeline: ingestion، embedding، پرسش و پاسخ.
+- UI چت پشتیبانی، مدیریت دانش ادمین.
+- گزارش‌ها و پنل مدیریتی.
+
+### Hardening (Post-Sprint)
+- تست امنیتی، بار، بهینه‌سازی latency.
+- مستندسازی و آموزش اپراتورها.
+
+---
+
+## 7. Acceptance Checklist
+
+- پیام‌ها قبل از انتشار توسط سرویس moderation بررسی و تصمیم ثبت می‌شود.
+- امتیاز انضباطی با Thresholdهای قابل تنظیم اعمال و قابل مشاهده است.
+- چت پشتیبانی حداقل 80٪ سوالات سناریوی آزمایشی را پاسخ می‌دهد و منابع را نشان می‌دهد.
+- ادمین می‌تواند سیاست‌ها، دانش‌پایه و اعتراض‌ها را مدیریت کند.
+- نرخ ارسال پیام، ترافیک moderation و گزارش‌ها در داشبورد قابل مشاهده است.
+


### PR DESCRIPTION
## Summary
- allow the API to construct claims from development debug headers when JWT auth is disabled and document the required headers for local use
- extend the shared API client to support a session-based auth context that emits the debug headers and update chat, support, knowledge-base, and appeals panels to honour the new auth signals

## Testing
- not run (tooling unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e13d1ab43c8329a42d7089fe7d47a1